### PR TITLE
Change heartbeat directory name and refactor file

### DIFF
--- a/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
@@ -17,6 +17,8 @@
 #import "GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorage.h"
 #import "GoogleUtilities/Environment/Public/GoogleUtilities/GULSecureCoding.h"
 
+NSString *const kGULHeartbeatStorageDirectory = @"GoogleHeartbeatStorage";
+
 @interface GULHeartbeatDateStorage ()
 /** The storage to store the date of the last sent heartbeat. */
 @property(nonatomic, readonly) NSFileCoordinator *fileCoordinator;
@@ -29,9 +31,7 @@
 @synthesize fileURL = _fileURL;
 
 - (instancetype)initWithFileName:(NSString *)fileName {
-  if (fileName == nil) {
-    return nil;
-  }
+  if (fileName == nil) return nil;
 
   self = [super init];
   if (self) {
@@ -41,13 +41,13 @@
   return self;
 }
 
-/** Lazy getter for fileURL
+/** Lazy getter for fileURL.
  * @return fileURL where heartbeat information is stored.
  */
 - (NSURL *)fileURL {
   if (!_fileURL) {
-    NSURL *directoryURL = [[self class] directoryPathURL];
-    [[self class] checkAndCreateDirectory:directoryURL fileCoordinator:_fileCoordinator];
+    NSURL *directoryURL = [self directoryPathURL];
+    [self checkAndCreateDirectory:directoryURL fileCoordinator:_fileCoordinator];
     _fileURL = [directoryURL URLByAppendingPathComponent:_fileName];
   }
   return _fileURL;
@@ -56,26 +56,25 @@
 /** Returns the URL path of the directory for heartbeat storage data.
  * @return the URL path of the directory for heartbeat storage data.
  */
-+ (NSURL *)directoryPathURL {
+- (NSURL *)directoryPathURL {
+  NSArray<NSString *> *paths;
 #if TARGET_OS_TV
-  NSArray<NSString *> *paths =
-      NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+  paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
 #else
-  NSArray<NSString *> *paths =
-      NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-#endif
-  NSArray<NSString *> *components = @[ paths.lastObject, @"Google/FIRApp" ];
-  NSString *directoryString = [NSString pathWithComponents:components];
-  NSURL *directoryURL = [NSURL fileURLWithPath:directoryString];
+  paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+#endif  // TARGET_OS_TV
+  NSString *rootPath = [paths firstObject];
+  NSURL *rootURL = [NSURL fileURLWithPath:rootPath];
+  NSURL *directoryURL = [rootURL URLByAppendingPathComponent:kGULHeartbeatStorageDirectory];
   return directoryURL;
 }
 
-/** Checks and creates a directory for the directory specified by the
- * directory url
- * @param directoryPathURL The path to the directory which needs to be created.
- * @param fileCoordinator The fileCoordinator object to coordinate writes to the directory.
+/** Check for the existence of the directory specified by the URL, and create it if it does not
+ * exist.
+ * @param directoryPathURL The path to the directory that needs to exist.
+ * @param fileCoordinator The `NSFileCoordinator` object that coordinates writes to the directory.
  */
-+ (void)checkAndCreateDirectory:(NSURL *)directoryPathURL
+- (void)checkAndCreateDirectory:(NSURL *)directoryPathURL
                 fileCoordinator:(NSFileCoordinator *)fileCoordinator {
   NSError *fileCoordinatorError = nil;
   [fileCoordinator
@@ -85,7 +84,6 @@
                       byAccessor:^(NSURL *writingDirectoryURL) {
                         NSError *error;
                         if (![writingDirectoryURL checkResourceIsReachableAndReturnError:&error]) {
-                          // If fail creating the Application Support directory, log warning.
                           NSError *error;
                           [[NSFileManager defaultManager] createDirectoryAtURL:writingDirectoryURL
                                                    withIntermediateDirectories:YES
@@ -95,65 +93,68 @@
                       }];
 }
 
-- (nullable NSMutableDictionary *)heartbeatDictionaryWithFileURL:(NSURL *)readingFileURL {
+- (nullable NSDictionary *)heartbeatDictionaryWithFileURL:(NSURL *)readingFileURL {
+  NSDictionary *heartbeatDictionary = [NSDictionary new];
+
   NSError *error;
-  NSMutableDictionary *dict;
   NSData *objectData = [NSData dataWithContentsOfURL:readingFileURL options:0 error:&error];
-  if (objectData == nil || error != nil) {
-    dict = [NSMutableDictionary dictionary];
-  } else {
-    dict = [GULSecureCoding
-        unarchivedObjectOfClasses:[NSSet setWithArray:@[ NSDictionary.class, NSDate.class ]]
-                         fromData:objectData
-                            error:&error];
-    if (dict == nil || error != nil) {
-      dict = [NSMutableDictionary dictionary];
+
+  if (objectData.length > 0 && error == nil) {
+    NSSet<Class> *objectClasses = [NSSet setWithArray:@[ NSDictionary.class, NSDate.class ]];
+    heartbeatDictionary = [GULSecureCoding unarchivedObjectOfClasses:objectClasses
+                                                            fromData:objectData
+                                                               error:&error];
+    if (heartbeatDictionary.count == 0 || error != nil) {
+      heartbeatDictionary = [NSDictionary new];
     }
   }
-  return dict;
+
+  return heartbeatDictionary;
 }
 
 - (nullable NSDate *)heartbeatDateForTag:(NSString *)tag {
-  __block NSMutableDictionary *dict;
+  __block NSDictionary *heartbeatDictionary;
   NSError *error;
   [self.fileCoordinator coordinateReadingItemAtURL:self.fileURL
                                            options:0
                                              error:&error
                                         byAccessor:^(NSURL *readingURL) {
-                                          dict = [self heartbeatDictionaryWithFileURL:readingURL];
+                                          heartbeatDictionary =
+                                              [self heartbeatDictionaryWithFileURL:readingURL];
                                         }];
-  return dict[tag];
+  return heartbeatDictionary[tag];
 }
 
 - (BOOL)setHearbeatDate:(NSDate *)date forTag:(NSString *)tag {
   NSError *error;
   __block BOOL isSuccess = false;
-  [self.fileCoordinator coordinateReadingItemAtURL:self.fileURL
-                                           options:0
-                                  writingItemAtURL:self.fileURL
-                                           options:0
-                                             error:&error
-                                        byAccessor:^(NSURL *readingURL, NSURL *writingURL) {
-                                          NSMutableDictionary *dictionary =
-                                              [self heartbeatDictionaryWithFileURL:readingURL];
-                                          dictionary[tag] = date;
-                                          NSError *error;
-                                          isSuccess = [self writeDictionary:dictionary
-                                                              forWritingURL:writingURL
-                                                                      error:&error];
-                                        }];
+  [self.fileCoordinator
+      coordinateReadingItemAtURL:self.fileURL
+                         options:0
+                writingItemAtURL:self.fileURL
+                         options:0
+                           error:&error
+                      byAccessor:^(NSURL *readingURL, NSURL *writingURL) {
+                        NSMutableDictionary *heartbeatDictionary =
+                            [[self heartbeatDictionaryWithFileURL:readingURL] mutableCopy];
+                        heartbeatDictionary[tag] = date;
+                        NSError *error;
+                        isSuccess = [self writeDictionary:heartbeatDictionary
+                                            forWritingURL:writingURL
+                                                    error:&error];
+                      }];
   return isSuccess;
 }
 
-- (BOOL)writeDictionary:(NSMutableDictionary *)dictionary
+- (BOOL)writeDictionary:(NSDictionary *)dictionary
           forWritingURL:(NSURL *)writingFileURL
                   error:(NSError **)outError {
   NSData *data = [GULSecureCoding archivedDataWithRootObject:dictionary error:outError];
   if (*outError != nil) {
     return false;
-  } else {
-    return [data writeToURL:writingFileURL atomically:YES];
   }
+
+  return [data writeToURL:writingFileURL atomically:YES];
 }
 
 @end

--- a/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
@@ -149,7 +149,7 @@ NSString *const kGULHeartbeatStorageDirectory = @"GoogleHeartbeatStorage";
           forWritingURL:(NSURL *)writingFileURL
                   error:(NSError **)outError {
   NSData *data = [GULSecureCoding archivedDataWithRootObject:dictionary error:outError];
-  if (data.length == 0 || *outError != nil) {
+  if (data.length == 0) {
     return NO;
   }
 

--- a/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
@@ -139,7 +139,7 @@ NSString *const kGULHeartbeatStorageDirectory = @"GoogleHeartbeatStorage";
                             [[self heartbeatDictionaryWithFileURL:readingURL] mutableCopy];
                         heartbeatDictionary[tag] = date;
                         NSError *error;
-                        isSuccess = [self writeDictionary:heartbeatDictionary
+                        isSuccess = [self writeDictionary:heartbeatDictionary.copy
                                             forWritingURL:writingURL
                                                     error:&error];
                       }];

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorage.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorage.h
@@ -18,6 +18,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// The name of the directory where the heartbeat data is stored.
+extern NSString *const kGULHeartbeatStorageDirectory;
+
 /// Stores either a date or a dictionary to a specified file.
 @interface GULHeartbeatDateStorage : NSObject
 

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -81,7 +81,7 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTest";
       NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
 #endif
   NSString *rootPath = [path firstObject];
-  NSArray<NSString *> *components = @[rootPath, kGULHeartbeatStorageDirectory, kTestFileName];
+  NSArray<NSString *> *components = @[ rootPath, kGULHeartbeatStorageDirectory, kTestFileName ];
   NSString *fileString = [NSString pathWithComponents:components];
   NSURL *fileURL = [NSURL fileURLWithPath:fileString];
   return fileURL;

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -81,7 +81,7 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTest";
       NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
 #endif
   NSString *rootPath = [path firstObject];
-  NSArray<NSString *> *components = @[ rootPath, @"Google/FIRApp", kTestFileName ];
+  NSArray<NSString *> *components = @[rootPath, kGULHeartbeatStorageDirectory, kTestFileName];
   NSString *fileString = [NSString pathWithComponents:components];
   NSURL *fileURL = [NSURL fileURLWithPath:fileString];
   return fileURL;


### PR DESCRIPTION
• Renaming heartbeat storage directory from "Google/FIRApp" to "GoogleHeartbeatStorage".
• Refactored `GULHeartbeatDateStorage.m` in an effort to make it more readable.

**Context**
`GULHeartbeatDateStorage` related crashes like [this one](https://github.com/firebase/firebase-ios-sdk/issues/7772) may occur because the current heartbeat storage directory is "Google/FIRApp", which makes "Google" the parent directory and  "FIRApp" the child directory.  When `GULHeartbeatDateStorage` instances call `checkAndCreateDirectory:fileCoordinator:` from different threads, the current heartbeat storage directory might be causing blocking issues because `NSFileCoordinator`'s `coordinateWritingItemAtURL:options:error:byAccessor:` method used in `checkAndCreateDirectory:fileCoordinator:` [does not wait for readers or writers that are manipulating the parent directory of the directory](https://developer.apple.com/documentation/foundation/nsfilecoordinator/1413344-coordinatewritingitematurl?language=objc#discussion:~:text=This%20method%20does%20not%20wait%20for,the%20parent%20directory%20of%20the%20file).

Fix [#7772](https://github.com/firebase/firebase-ios-sdk/issues/7772)