### PR TITLE
Disable jobs when secrets are not available

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -62,7 +62,7 @@ jobs:
         cd firebase-ios-sdk/scripts/code_coverage_report/generate_code_coverage_report/
         swift build
     - name: Generate report
-      if: github.event.pull_request.merged != true && ${{ env.METRICS_SERVICE_SECRET }}
+      if: github.event.pull_request.merged != true && env.METRICS_SERVICE_SECRET
       env:
         pr_branch: ${{ github.event.pull_request.head.ref }}
       run: |
@@ -72,7 +72,7 @@ jobs:
         firebase-ios-sdk/scripts/code_coverage_report/generate_code_coverage_report/.build/debug/CoverageReportGenerator --presubmit "google/GoogleUtilities" --commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --xcresult-dir "${{steps.download.outputs.download-path}}/codecoverage" --log-link "https://github.com/google/GoogleUtilities/actions/runs/${GITHUB_RUN_ID}" --pull-request-num ${{github.event.pull_request.number}} --base-commit "$common_commit"
         fi
     - name: Update New Coverage Data
-      if: github.event.pull_request.merged == true && ${{ env.METRICS_SERVICE_SECRET }}
+      if: github.event.pull_request.merged == true && env.METRICS_SERVICE_SECRET
       run: |
         if [ -d "${{steps.download.outputs.download-path}}" ]; then
         firebase-ios-sdk/scripts/code_coverage_report/generate_code_coverage_report/.build/debug/CoverageReportGenerator --merge "google/GoogleUtilities" --commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --xcresult-dir "${{steps.download.outputs.download-path}}/codecoverage" --log-link "https://github.com/google/GoogleUtilities/actions/runs/${GITHUB_RUN_ID}" --branch "${GITHUB_REF##*/}"


### PR DESCRIPTION
The previous setup will always run two jobs,  `Generate report` and `Update New Coverage Data`, in sequence in both presubmit and postsubmit. The workflow will fail while `Generate report` job runs for postsubmit/merge since pr_branch cannot be fetched properly. Also, this job should not run in postsubmit/merge.