### PR TITLE
Introduce UserDefaults based heartbeat storage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 7.4.0
 - Change heartbeat directory name and refactor file. (#19)
-- Introduce user defaults based heartbeat storage. (#9)
+- Introduce user defaults based heartbeat storage. (#23)
 
 # 7.3.1
 - Add explicit dependency on Security framework to Environment subspec. (#12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 7.3.2
+# 7.4.0
 - Change heartbeat directory name and refactor file. (#19)
+- Introduce user defaults based heartbeat storage. (#9)
 
 # 7.3.1
 - Add explicit dependency on Security framework to Environment subspec. (#12)

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '7.3.2'
+  s.version          = '7.4.0'
   s.summary          = 'Google Utilities for Apple platform SDKs'
 
   s.description      = <<-DESC

--- a/GoogleUtilities/Environment/GULHeartbeatDateStorageUserDefaults.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorageUserDefaults.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleUtilities/Environment/GULHeartbeatDateStorageUserDefaults.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorageUserDefaults.m
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorageUserDefaults.h"
+
+@interface GULHeartbeatDateStorageUserDefaults ()
+
+/** The storage to store the date of the last sent heartbeat. */
+@property(nonatomic, readonly) NSUserDefaults *userDefaults;
+
+/** The key for user defaults to store heartbeat information. */
+@property(nonatomic, readonly) NSString *key;
+
+@end
+
+@implementation GULHeartbeatDateStorageUserDefaults
+
+- (instancetype)initWithDefaults:(NSUserDefaults *)defaults key:(NSString *)key {
+  self = [super init];
+  if (self) {
+    _userDefaults = defaults;
+    _key = key;
+  }
+  return self;
+}
+
+- (nullable NSMutableDictionary *)heartbeatDictionaryFromDefaults {
+  NSDictionary *heartbeatDict = [self.userDefaults objectForKey:self.key];
+  if (heartbeatDict != nil) {
+    return [heartbeatDict mutableCopy];
+  } else {
+    return [NSMutableDictionary dictionary];
+  }
+}
+
+- (nullable NSDate *)heartbeatDateForTag:(NSString *)tag {
+  NSDate *date = nil;
+  @synchronized(self.userDefaults) {
+    NSMutableDictionary *dict = [self heartbeatDictionaryFromDefaults];
+    date = dict[tag];
+  }
+
+  return date;
+}
+
+- (BOOL)setHearbeatDate:(NSDate *)date forTag:(NSString *)tag {
+  @synchronized(self.userDefaults) {
+    NSMutableDictionary *dict = [self heartbeatDictionaryFromDefaults];
+    dict[tag] = date;
+    [self.userDefaults setObject:dict forKey:self.key];
+  }
+  return true;
+}
+
+@end

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorable.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorable.h
@@ -35,7 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)setHearbeatDate:(NSDate *)date forTag:(NSString *)tag;
 
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorable.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import "GULHeartbeatDateStorable.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
-/// The name of the directory where the heartbeat data is stored.
-extern NSString *const kGULHeartbeatStorageDirectory;
-
-/// Stores either a date or a dictionary to a specified file.
-@interface GULHeartbeatDateStorage : NSObject<GULHeartbeatDateStorable>
-
-- (instancetype)init NS_UNAVAILABLE;
-
-@property(nonatomic, readonly) NSURL *fileURL;
-
 /**
- * Default initializer.
- * @param fileName The name of the file to store the date information.
- * exist, it will be created if needed.
+ * Describes an object that can store and fetch heartbeat dates for given tags.
  */
-- (instancetype)initWithFileName:(NSString *)fileName;
+@protocol GULHeartbeatDateStorable <NSObject>
 
 /**
  * Reads the date from the specified file for the given tag.
@@ -48,6 +34,7 @@ extern NSString *const kGULHeartbeatStorageDirectory;
  * @return YES on success, NO otherwise.
  */
 - (BOOL)setHearbeatDate:(NSDate *)date forTag:(NSString *)tag;
+
 
 @end
 

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorage.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorage.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *const kGULHeartbeatStorageDirectory;
 
 /// Stores either a date or a dictionary to a specified file.
-@interface GULHeartbeatDateStorage : NSObject<GULHeartbeatDateStorable>
+@interface GULHeartbeatDateStorage : NSObject <GULHeartbeatDateStorable>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorageUserDefaults.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorageUserDefaults.h
@@ -21,7 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Stores either a date or a dictionary to a specified file.
-@interface GULHeartbeatDateStorageUserDefaults : NSObject<GULHeartbeatDateStorable>
+@interface GULHeartbeatDateStorageUserDefaults : NSObject <GULHeartbeatDateStorable>
 
 /**
  * Default initializer. tvOS can only write to the cache directory and
@@ -30,8 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param defaults User defaults instance to store the heartbeat information.
  * @param key The key to be used with the user defaults instance.
  */
-- (instancetype)initWithDefaults:(NSUserDefaults *)defaults
-                             key:(NSString *)key;
+- (instancetype)initWithDefaults:(NSUserDefaults *)defaults key:(NSString *)key;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorageUserDefaults.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorageUserDefaults.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,22 +20,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// The name of the directory where the heartbeat data is stored.
-extern NSString *const kGULHeartbeatStorageDirectory;
-
 /// Stores either a date or a dictionary to a specified file.
-@interface GULHeartbeatDateStorage : NSObject<GULHeartbeatDateStorable>
-
-- (instancetype)init NS_UNAVAILABLE;
-
-@property(nonatomic, readonly) NSURL *fileURL;
+@interface GULHeartbeatDateStorageUserDefaults : NSObject<GULHeartbeatDateStorable>
 
 /**
- * Default initializer.
- * @param fileName The name of the file to store the date information.
- * exist, it will be created if needed.
+ * Default initializer. tvOS can only write to the cache directory and
+ * there are no guarantees that the directory will persist. User defaults will
+ * be retained, so that should be used instead.
+ * @param defaults User defaults instance to store the heartbeat information.
+ * @param key The key to be used with the user defaults instance.
  */
-- (instancetype)initWithFileName:(NSString *)fileName;
+- (instancetype)initWithDefaults:(NSUserDefaults *)defaults
+                             key:(NSString *)key;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  * Reads the date from the specified file for the given tag.

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageUserDefaultsTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageUserDefaultsTest.m
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorage.h"
+
+@interface GULHeartbeatDateStorageTest : XCTestCase
+@property(nonatomic) GULHeartbeatDateStorage *storage;
+@end
+
+static NSString *const kTestFileName = @"GULStorageHeartbeatTest";
+
+@implementation GULHeartbeatDateStorageTest
+
+- (void)setUp {
+#if TARGET_OS_TV
+  NSArray *path = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+#else
+  NSArray *path =
+      NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+#endif
+  NSString *rootPath = [path firstObject];
+  XCTAssertNotNil(rootPath);
+  NSURL *rootURL = [NSURL fileURLWithPath:rootPath];
+
+  NSError *error;
+  if (![rootURL checkResourceIsReachableAndReturnError:&error]) {
+    XCTAssert([[NSFileManager defaultManager] createDirectoryAtURL:rootURL
+                                       withIntermediateDirectories:YES
+                                                        attributes:nil
+                                                             error:&error],
+              @"Error: %@", error);
+  }
+
+  self.storage = [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];
+
+  [self assertInitializationDoesNotAccessFileSystem];
+}
+
+- (void)tearDown {
+  [[NSFileManager defaultManager] removeItemAtURL:[self.storage fileURL] error:nil];
+  self.storage = nil;
+}
+
+- (void)testHeartbeatDateForTag {
+  NSDate *now = [NSDate date];
+  [self.storage setHearbeatDate:now forTag:@"fire-iid"];
+  XCTAssertEqual([now timeIntervalSinceReferenceDate],
+                 [[self.storage heartbeatDateForTag:@"fire-iid"] timeIntervalSinceReferenceDate]);
+}
+
+- (void)testConformsToHeartbeatStorableProtocol {
+  XCTAssertTrue([self.storage conformsToProtocol:@protocol(GULHeartbeatDateStorable)]);
+}
+
+#pragma mark - Private Helpers
+
+- (void)assertInitializationDoesNotAccessFileSystem {
+  NSURL *fileURL = [self heartbeatFileURL];
+  NSError *error;
+  BOOL fileIsReachable = [fileURL checkResourceIsReachableAndReturnError:&error];
+  XCTAssertFalse(fileIsReachable,
+                 @"GULHeartbeatDateStorage initialization should not access the file system.");
+  XCTAssertNotNil(error, @"Error: %@", error);
+}
+
+- (NSURL *)heartbeatFileURL {
+#if TARGET_OS_TV
+  NSArray *path = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+#else
+  NSArray *path =
+      NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+#endif
+  NSString *rootPath = [path firstObject];
+  NSArray<NSString *> *components = @[ rootPath, kGULHeartbeatStorageDirectory, kTestFileName ];
+  NSString *fileString = [NSString pathWithComponents:components];
+  NSURL *fileURL = [NSURL fileURLWithPath:fileString];
+  return fileURL;
+}
+
+@end

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageUserDefaultsTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageUserDefaultsTest.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This can be used on tvOS without fear of losing data between launches.
Clients will need to instantiate the class of their choice, then can use the
`GULHeartbeatDateStorable` protocol if they want to mix and match.