### PR TITLE
Revert heartbeat storage directory name (Firebase 8)

### DIFF
--- a/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
@@ -17,7 +17,7 @@
 #import "GoogleUtilities/Environment/Public/GoogleUtilities/GULHeartbeatDateStorage.h"
 #import "GoogleUtilities/Environment/Public/GoogleUtilities/GULSecureCoding.h"
 
-NSString *const kGULHeartbeatStorageDirectory = @"GoogleHeartbeatStorage";
+NSString *const kGULHeartbeatStorageDirectory = @"Google/FIRApp";
 
 @interface GULHeartbeatDateStorage ()
 /** The storage to store the date of the last sent heartbeat. */
@@ -63,7 +63,7 @@ NSString *const kGULHeartbeatStorageDirectory = @"GoogleHeartbeatStorage";
 #else
   paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
 #endif  // TARGET_OS_TV
-  NSString *rootPath = [paths firstObject];
+  NSString *rootPath = [paths lastObject];
   NSURL *rootURL = [NSURL fileURLWithPath:rootPath];
   NSURL *directoryURL = [rootURL URLByAppendingPathComponent:kGULHeartbeatStorageDirectory];
   return directoryURL;


### PR DESCRIPTION
This PR **reverts the change** to the heartbeat directory name that was done in #19. 

Logically, the only difference between this PR's change and the head of `main` before changing the heartbeat directory name in #19 should be that the directory name is getting changed from `GoogleHeartbeatStorage` **back to** `Google/FIRApp`.

Relevant files in the diff between this PR's latest commit and head of `main` before #19:
• [GULHeartbeatStorage.m](https://github.com/google/GoogleUtilities/compare/0faf34d4b55fb9d048e2082ebed9fea5e97412e0...bbd4173f76fac863ca4b5fb596b62488cbaeb549#diff-491f83b78a347cd3aac52b47123f5e607bb5c3242ae3c0ab6c0601b77cfb66d9)
• [GULHeartbeatStorage.h](https://github.com/google/GoogleUtilities/compare/0faf34d4b55fb9d048e2082ebed9fea5e97412e0...bbd4173f76fac863ca4b5fb596b62488cbaeb549#diff-2fe7a17273dfefa2e5f5e3f22f9e45e5e83353e8f95602955df682903554fedeR24)
• [GULHeartbeatStorageTest.m](https://github.com/google/GoogleUtilities/compare/0faf34d4b55fb9d048e2082ebed9fea5e97412e0...bbd4173f76fac863ca4b5fb596b62488cbaeb549#diff-072bd421e1c49c2477c143472c35d1716f3814ef60fe47f3a843df6c91722d7f)
