### PR TITLE
Support iOS 9 with SwiftPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 7.4.0
 - Change heartbeat directory name and refactor file. (#19)
 - Introduce user defaults based heartbeat storage. (#23)
+- Support iOS 9 with Swift Package Manager.
 
 # 7.3.1
 - Add explicit dependency on Security framework to Environment subspec. (#12)

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let package = Package(
   name: "GoogleUtilities",
-  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v6)],
+  platforms: [.iOS(.v9), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v6)],
   products: [
     .library(
       name: "GULAppDelegateSwizzler",


### PR DESCRIPTION
To enable GoogleSignIn and iOS 9

Low risk since CocoaPods already supports iOS 9