### PR TITLE
remove HTML tags around email address in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -206,7 +206,7 @@
 The following copyright from Landon J. Fuller applies to the isAppEncrypted
 function in Environment/third_party/GULAppEnvironmentUtil.m.
 
-Copyright (c) 2017 Landon J. Fuller <landon@landonf.org>
+Copyright (c) 2017 Landon J. Fuller landon@landonf.org
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
In our use case, we concatenate all our license file into one large Markdown file. As GoogleUtilities is not the last markdown file to be included, the open <landon@landonf.org> tag prevents the remaining markdown from being parsed correctly into HTML.