### PR TITLE
Include all object classes when using archiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Include all object classes when using archiver. (#42)
+
 # 7.4.1
 - Improve heartbeat date storage's version compatability. (#37)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 7.4.2
 - Include all object classes when using archiver. (#42)
 
 # 7.4.1

--- a/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
@@ -136,7 +136,8 @@ NSString *const kGULHeartbeatStorageDirectory = @"Google/FIRApp";
   NSData *objectData = [NSData dataWithContentsOfURL:readingFileURL options:0 error:&error];
 
   if (objectData.length > 0 && error == nil) {
-    NSSet<Class> *objectClasses = [NSSet setWithArray:@[ NSDictionary.class, NSDate.class ]];
+    NSSet<Class> *objectClasses =
+        [NSSet setWithArray:@[ NSDictionary.class, NSDate.class, NSString.class ]];
     heartbeatDictionary = [GULSecureCoding unarchivedObjectOfClasses:objectClasses
                                                             fromData:objectData
                                                                error:&error];

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -424,7 +424,8 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
   NSURL *heartbeatStorageDirectoryURL = [self pathURLForDirectory:kGULHeartbeatStorageDirectory];
   NSURL *heartbeatStorageFileURL = [self fileURLForDirectory:heartbeatStorageDirectoryURL];
   NSData *objectData = [NSData dataWithContentsOfURL:heartbeatStorageFileURL options:0 error:nil];
-  __auto_type objectClasses = [NSSet setWithArray:@[ NSDictionary.class, NSDate.class ]];
+  __auto_type objectClasses =
+      [NSSet setWithArray:@[ NSDictionary.class, NSDate.class, NSString.class ]];
   NSMutableDictionary *heartbeatDict = [GULSecureCoding unarchivedObjectOfClasses:objectClasses
                                                                          fromData:objectData
                                                                             error:nil];

--- a/GoogleUtilities/Tests/Unit/Environment/GULKeychainStorageTests.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULKeychainStorageTests.m
@@ -87,6 +87,8 @@
 
   // 3. Read existing object which is not present in in-memory cache.
   [self.cache removeAllObjects];
+  // TODO: Evaluate if GULKeychainStorage needs an API that takes set of classes. (#42)
+  // The following method causes an NSKeyedUnarchiver-related runtime warning log.
   [self assertSuccessReadObject:@{@"key" : @"value"}
                          forKey:@"test-key1"
                           class:[NSDictionary class]

--- a/GoogleUtilities/Tests/Unit/SecureCoding/GULSecureCodingTests.m
+++ b/GoogleUtilities/Tests/Unit/SecureCoding/GULSecureCodingTests.m
@@ -60,7 +60,8 @@
   XCTAssertNotNil(archiveData);
 
   NSDictionary *unarchivedObject = [GULSecureCoding
-      unarchivedObjectOfClasses:[NSSet setWithArray:@[ NSDictionary.class, NSDate.class ]]
+      unarchivedObjectOfClasses:
+          [NSSet setWithArray:@[ NSDictionary.class, NSDate.class, NSString.class, NSNumber.class ]]
                        fromData:archiveData
                           error:&error];
   XCTAssertNil(error);

--- a/GoogleUtilities/Tests/Unit/SecureCoding/GULSecureCodingTests.m
+++ b/GoogleUtilities/Tests/Unit/SecureCoding/GULSecureCodingTests.m
@@ -37,18 +37,16 @@
 @implementation GULSecureCodingTests
 
 - (void)testArchiveUnarchiveSingleClass {
-  NSDictionary *objectToArchive = @{@"key1" : @"value1", @"key2" : @(2)};
+  NSDictionary *objectToArchive = @{};
 
   NSError *error;
   NSData *archiveData = [GULSecureCoding archivedDataWithRootObject:objectToArchive error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(archiveData);
 
-  NSSet<Class> *objectClasses =
-      [NSSet setWithArray:@[ NSDictionary.class, NSDate.class, NSString.class, NSNumber.class ]];
-  NSDictionary *unarchivedObject = [GULSecureCoding unarchivedObjectOfClasses:objectClasses
-                                                                     fromData:archiveData
-                                                                        error:&error];
+  NSDictionary *unarchivedObject = [GULSecureCoding unarchivedObjectOfClass:[NSDictionary class]
+                                                                   fromData:archiveData
+                                                                      error:&error];
   XCTAssertNil(error);
   XCTAssert([objectToArchive isEqualToDictionary:unarchivedObject]);
 }

--- a/GoogleUtilities/Tests/Unit/SecureCoding/GULSecureCodingTests.m
+++ b/GoogleUtilities/Tests/Unit/SecureCoding/GULSecureCodingTests.m
@@ -44,9 +44,11 @@
   XCTAssertNil(error);
   XCTAssertNotNil(archiveData);
 
-  NSDictionary *unarchivedObject = [GULSecureCoding unarchivedObjectOfClass:[NSDictionary class]
-                                                                   fromData:archiveData
-                                                                      error:&error];
+  NSSet<Class> *objectClasses =
+      [NSSet setWithArray:@[ NSDictionary.class, NSDate.class, NSString.class, NSNumber.class ]];
+  NSDictionary *unarchivedObject = [GULSecureCoding unarchivedObjectOfClasses:objectClasses
+                                                                     fromData:archiveData
+                                                                        error:&error];
   XCTAssertNil(error);
   XCTAssert([objectToArchive isEqualToDictionary:unarchivedObject]);
 }


### PR DESCRIPTION
Up until now (Xcode 13 beta 1), [property list supported types](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/AboutPropertyLists/AboutPropertyLists.html#//apple_ref/doc/uid/10000048i-CH3-54303) didn't need to be explicitly included in the [class set when unarchiving an object.](https://developer.apple.com/documentation/foundation/nskeyedunarchiver/2962885-unarchivedobjectofclasses?language=objc) From now on however, a warning logs at runtime when an object is unarchived using `NSKeyedUnarchiver` without explicitly mentioning any  plist supported types that are associated with that object's unarchiving.

Fixes [#8276](https://github.com/firebase/firebase-ios-sdk/issues/8276)