### PR TITLE
Prep for 7.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 7.4.3
 - Include all object classes when using archiver. (#42)
 
-# 7.4.2
-- This was a SwiftPM-only release.
+# 7.4.2 (Swift PM)
+- Fix warnings in Xcode 13 beta 1. (#41)
 
 # 7.4.1
 - Improve heartbeat date storage's version compatability. (#37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-# 7.4.2
+# 7.4.3
 - Include all object classes when using archiver. (#42)
+
+# 7.4.2
+- This was a SwiftPM-only release.
 
 # 7.4.1
 - Improve heartbeat date storage's version compatability. (#37)

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '7.4.2'
+  s.version          = '7.4.3'
   s.summary          = 'Google Utilities for Apple platform SDKs'
 
   s.description      = <<-DESC

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ a customized adaptation.
 After the CI is green:
 * Determine the next version for release by checking the
   [tagged releases](https://github.com/google/GoogleUtilities/tags).
-  Ensure that the next release version keeps Swift PM and CocoaPods respective versions in in sync. 
+  Ensure that the next release version keeps Swift PM and CocoaPods respective versions in in sync.
 * Verify that the releasing version has the latest entry in the [CHANGELOG.md](CHANGELOG.md),
   updating it if necessary. 
 * Update the version in the podspec to match the latest entry in the [CHANGELOG.md](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ After the CI is green:
   [tagged releases](https://github.com/google/GoogleUtilities/tags).
   Ensure that the next release version keeps Swift PM and CocoaPods respective versions in in sync.
 * Verify that the releasing version has the latest entry in the [CHANGELOG.md](CHANGELOG.md),
-  updating it if necessary. 
+  updating it if necessary.
 * Update the version in the podspec to match the latest entry in the [CHANGELOG.md](CHANGELOG.md)
 * Checkout the `main` branch and ensure it is up to date
   ```console

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ These instructions apply to minor and patch version updates. Major versions need
 a customized adaptation.
 
 After the CI is green:
+* Determine the next version for release by checking the
+  [tagged releases](https://github.com/google/GoogleUtilities/tags).
+  Ensure that the next release version keeps Swift PM and CocoaPods respective versions in in sync. 
+* Verify that the releasing version has the latest entry in the [CHANGELOG.md](CHANGELOG.md),
+  updating it if necessary. 
 * Update the version in the podspec to match the latest entry in the [CHANGELOG.md](CHANGELOG.md)
 * Checkout the `main` branch and ensure it is up to date
   ```console


### PR DESCRIPTION
Next CocoaPods release will jump from 7.4.**1** → 7.4.**3** to account for SwiftPM-only 7.4.**2** release. 
With 7.4.3, both the CP and SPM release will be in sync.

• Updated spec to 7.4.3
• Updated CHANGELOG
• Update release instruction in README