### PR TITLE
Update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ a customized adaptation.
 
 After the CI is green:
 * Determine the next version for release by checking the
-  [tagged releases](https://github.com/google/GoogleUtilities/tags).
-  Ensure that the next release version keeps Swift PM and CocoaPods respective versions in in sync.
-* Verify that the releasing version has the latest entry in the [CHANGELOG.md](CHANGELOG.md),
+  [tagged releases](https://github.com/google/GoogleDataTransport/tags).
+  Ensure that the next release version keeps the Swift PM and CocoaPods versions in sync.
+* Verify that the releasing version is the latest entry in the [CHANGELOG.md](CHANGELOG.md),
   updating it if necessary.
 * Update the version in the podspec to match the latest entry in the [CHANGELOG.md](CHANGELOG.md)
 * Checkout the `main` branch and ensure it is up to date
@@ -69,7 +69,8 @@ After the CI is green:
 The release process is as follows:
 1. [Tag and release for Swift PM](#swift-package-manager)
 2. [Publish to CocoaPods](#cocoapods)
-3. [Perform post release cleanup](#post-release-cleanup)
+3. [Create GitHub Release](#create-github-release)
+4. [Perform post release cleanup](#post-release-cleanup)
 
 ### Swift Package Manager
   By creating and [pushing a tag](https://github.com/google/GoogleUtilities/tags)
@@ -97,19 +98,31 @@ The release process is as follows:
   In addition, a new commit that publishes the new version (co-authored by [CocoaPodsAtGoogle](https://github.com/CocoaPodsAtGoogle))
   should appear in the [CocoaPods specs repo](https://github.com/CocoaPods/Specs). Last, the latest version should be displayed
   on [GoogleUtilities's CocoaPods page](https://cocoapods.org/pods/GoogleUtilities).
+  
+### [Create GitHub Release](https://github.com/google/GoogleDataTransport/releases/new/)
+  Update the [release template](https://github.com/google/GoogleDataTransport/releases/new/)'s **Tag version** and **Release title**
+  fields with the latest version. In addition, reference the [Release Notes](./CHANGELOG.md) in the release's description.
+
+  See [this release](https://github.com/google/GoogleDataTransport/releases/edit/9.0.1) for an example.
 
   *Don't forget to perform the [post release cleanup](#post-release-cleanup)!*
 
 ### Post Release Cleanup
-* Clean up [SpecsStaging](https://github.com/firebase/SpecsStaging):
+  <details>
+  <summary>Clean up <b>SpecsStaging</b></summary> 
+
   ```console
-  cd ~/path/to/SpecsStaging/
-  git checkout master
-  git pull
+  pwd=$(pwd)
+  mkdir -p /tmp/release-cleanup && cd $_
+  git clone git@github.com:firebase/SpecsStaging.git
+  cd SpecsStaging/
   git rm -rf GoogleUtilities/
-  git commit -m "Post GoogleUtilities {version} release cleanup"
-  git push
-  ```
+  git commit -m "Post publish cleanup"
+  git push origin master
+  rm -rf /tmp/release-cleanup 
+  cd $pwd
+  ```  
+  </details>
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The release process is as follows:
   In addition, a new commit that publishes the new version (co-authored by [CocoaPodsAtGoogle](https://github.com/CocoaPodsAtGoogle))
   should appear in the [CocoaPods specs repo](https://github.com/CocoaPods/Specs). Last, the latest version should be displayed
   on [GoogleUtilities's CocoaPods page](https://cocoapods.org/pods/GoogleUtilities).
-  
+
 ### [Create GitHub Release](https://github.com/google/GoogleDataTransport/releases/new/)
   Update the [release template](https://github.com/google/GoogleDataTransport/releases/new/)'s **Tag version** and **Release title**
   fields with the latest version. In addition, reference the [Release Notes](./CHANGELOG.md) in the release's description.
@@ -109,7 +109,7 @@ The release process is as follows:
 
 ### Post Release Cleanup
   <details>
-  <summary>Clean up <b>SpecsStaging</b></summary> 
+  <summary>Clean up <b>SpecsStaging</b></summary>
 
   ```console
   pwd=$(pwd)
@@ -119,9 +119,9 @@ The release process is as follows:
   git rm -rf GoogleUtilities/
   git commit -m "Post publish cleanup"
   git push origin master
-  rm -rf /tmp/release-cleanup 
+  rm -rf /tmp/release-cleanup
   cd $pwd
-  ```  
+  ```
   </details>
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ a customized adaptation.
 
 After the CI is green:
 * Determine the next version for release by checking the
-  [tagged releases](https://github.com/google/GoogleDataTransport/tags).
+  [tagged releases](https://github.com/google/GoogleUtilities/tags).
   Ensure that the next release version keeps the Swift PM and CocoaPods versions in sync.
 * Verify that the releasing version is the latest entry in the [CHANGELOG.md](CHANGELOG.md),
   updating it if necessary.
@@ -99,11 +99,11 @@ The release process is as follows:
   should appear in the [CocoaPods specs repo](https://github.com/CocoaPods/Specs). Last, the latest version should be displayed
   on [GoogleUtilities's CocoaPods page](https://cocoapods.org/pods/GoogleUtilities).
 
-### [Create GitHub Release](https://github.com/google/GoogleDataTransport/releases/new/)
-  Update the [release template](https://github.com/google/GoogleDataTransport/releases/new/)'s **Tag version** and **Release title**
+### [Create GitHub Release](https://github.com/google/GoogleUtilities/releases/new/)
+  Update the [release template](https://github.com/google/GoogleUtilities/releases/new/)'s **Tag version** and **Release title**
   fields with the latest version. In addition, reference the [Release Notes](./CHANGELOG.md) in the release's description.
 
-  See [this release](https://github.com/google/GoogleDataTransport/releases/edit/9.0.1) for an example.
+  See [this release](https://github.com/google/GoogleUtilities/releases/edit/9.0.1) for an example.
 
   *Don't forget to perform the [post release cleanup](#post-release-cleanup)!*
 


### PR DESCRIPTION
Following GoogleUtilities 7.4.3 release, I went through updated GDT and GULs release instructions to be up-to-date and in sync.

Associated GDT PR https://github.com/google/GoogleDataTransport/pull/29

Also added copy and paste friendly block of release cleanup commands.