### PR TITLE
Fix CHANGELOG.md & Fix #46's spec bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 7.4.4
-- Bump promises dependency #46
+- Bump Promises dependency. (#46)
 
 # 7.4.3
 - Include all object classes when using archiver. (#42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 7.4.4
-- Bump Promises dependency. (#46)
+# 7.5.0
+- Bump Promises dependency. (#8334)
 
 # 7.4.3
 - Include all object classes when using archiver. (#42)

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '7.4.4'
+  s.version          = '7.5.0'
   s.summary          = 'Google Utilities for Apple platform SDKs'
 
   s.description      = <<-DESC


### PR DESCRIPTION
I see your comments on GDT PR, I bumped the GULs podspec from 7.4.3 to 7.4.4: https://github.com/google/GoogleUtilities/blob/main/GoogleUtilities.podspec#L3

Should I have bumped 7.5.0?