### PR TITLE
Objective-C Signpost API wrapper

### DIFF
--- a/GoogleUtilities/Logger/GULSignpostLogger.h
+++ b/GoogleUtilities/Logger/GULSignpostLogger.h
@@ -1,0 +1,57 @@
+//
+//  GULSignpostLogger.h
+//  GoogleUtilities
+//
+//  Created by Maksym Malyhin on 2021-07-07.
+//
+
+// Wrapper that allows using signpost (<os/signpost.h>) API when available and do nothing when it's not. It is introduced to reduce availability checks on the client side.
+
+#if __has_include(<os/signpost.h>)
+#import <os/signpost.h>
+
+typedef os_log_t gul_os_log_t;
+typedef os_signpost_id_t gul_os_signpost_id_t;
+
+// See `os_signpost_id_generate`.
+#define gul_os_signpost_id_generate(log) \
+  os_signpost_id_generate(log)
+
+// See `os_signpost_interval_begin`.
+#define gul_os_signpost_interval_begin(log, interval_id, name, ...) \
+  os_signpost_interval_begin(log, interval_id, name, ##__VA_ARGS__)
+
+// See `os_signpost_interval_end`.
+#define gul_os_signpost_interval_end(log, interval_id, name, ...) \
+  os_signpost_interval_end(log, interval_id, name, ##__VA_ARGS__)
+
+// See `os_signpost_interval_end`.
+#define gul_os_signpost_interval_emit(log, event_id, name, ...) \
+  os_signpost_interval_emit(log, event_id, name, ##__VA_ARGS__)
+
+// See `_gul_default_signpost_log`.
+#define gul_default_signpost_log() \
+  _gul_default_signpost_log
+
+#else // __has_include(<os/signpost.h>)
+
+// Placeholders for the signpost API methods and types when it's not available.
+
+typedef void gul_os_log_t;
+typedef void gul_os_signpost_id_t;
+
+#define gul_os_signpost_id_generate(log)
+
+#define gul_os_signpost_interval_begin(log, interval_id, name, ...)
+
+#define gul_os_signpost_interval_end(log, interval_id, name, ...)
+
+#define gul_os_signpost_interval_emit(log, event_id, name, ...)
+
+#define gul_default_signpost_log()
+
+#endif // __has_include(<os/signpost.h>)
+
+/// Returns a default instance of `gul_os_log_t` to be used for signpost logging when available.
+/// @return A default instance of `gul_os_log_t`.
+gul_os_log_t _gul_default_signpost_log(void);

--- a/GoogleUtilities/Logger/GULSignpostLogger.m
+++ b/GoogleUtilities/Logger/GULSignpostLogger.m
@@ -5,13 +5,23 @@
 //  Created by Maksym Malyhin on 2021-07-07.
 //
 
-#import "GULSignpostLogger.h"
+#import <Foundation/Foundation.h>
+
+#import "GoogleUtilities/Logger/Public/GoogleUtilities/GULSignpostLogger.h"
 
 gul_os_log_t _gul_default_signpost_log(void) {
   static gul_os_log_t _default_signpost_log;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    _default_signpost_log = os_log_create("com.GoogleUtilities.signpost", "signpost")
+    _default_signpost_log = os_log_create("com.GoogleUtilities.signpost", "signpost");
   });
   return _default_signpost_log;
+}
+
+void _gul_os_signpost_interval_begin(gul_os_log_t log, gul_os_signpost_id_t interval_id, const char *name, ...) {
+  if (@available(iOS 12.0, *)) {
+    os_signpost_interval_begin(log, interval_id, name, "" __VA_ARGS__);
+  } else {
+    // Fallback on earlier versions
+  }
 }

--- a/GoogleUtilities/Logger/GULSignpostLogger.m
+++ b/GoogleUtilities/Logger/GULSignpostLogger.m
@@ -18,10 +18,14 @@ gul_os_log_t _gul_default_signpost_log(void) {
   return _default_signpost_log;
 }
 
-void _gul_os_signpost_interval_begin(gul_os_log_t log, gul_os_signpost_id_t interval_id, const char *name, ...) {
+gul_os_signpost_id_t gul_os_signpost_id_generate(gul_os_log_t log) {
+#if __has_include(<os/signpost.h>)
   if (@available(iOS 12.0, *)) {
-    os_signpost_interval_begin(log, interval_id, name, "" __VA_ARGS__);
+    return os_signpost_id_generate(log);
   } else {
-    // Fallback on earlier versions
+    return 0;
   }
+#else // __has_include(<os/signpost.h>)
+  return 0;
+#endif // __has_include(<os/signpost.h>)
 }

--- a/GoogleUtilities/Logger/GULSignpostLogger.m
+++ b/GoogleUtilities/Logger/GULSignpostLogger.m
@@ -1,0 +1,17 @@
+//
+//  GULSignpostLogger.m
+//  GoogleUtilities
+//
+//  Created by Maksym Malyhin on 2021-07-07.
+//
+
+#import "GULSignpostLogger.h"
+
+gul_os_log_t _gul_default_signpost_log(void) {
+  static gul_os_log_t _default_signpost_log;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    _default_signpost_log = os_log_create("com.GoogleUtilities.signpost", "signpost")
+  });
+  return _default_signpost_log;
+}

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULSignpostLogger.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULSignpostLogger.h
@@ -13,36 +13,50 @@
 typedef os_log_t gul_os_log_t;
 typedef os_signpost_id_t gul_os_signpost_id_t;
 
-// See `os_signpost_id_generate`.
-#define gul_os_signpost_id_generate(log) \
-  os_signpost_id_generate(log)
-
 // See `os_signpost_interval_begin`.
 #define gul_os_signpost_interval_begin(log, interval_id, name, ...) \
- _gul_os_signpost_interval_begin(log, interval_id, name, ##__VA_ARGS__)
+    __extension__({ \
+        if (@available(iOS 12.0, *)) { \
+          os_signpost_interval_begin(log, interval_id, name, "" __VA_ARGS__); \
+        } \
+    })
 
 // See `os_signpost_interval_end`.
 #define gul_os_signpost_interval_end(log, interval_id, name, ...) \
-  os_signpost_interval_end(log, interval_id, name, ##__VA_ARGS__)
+    __extension__({ \
+        if (@available(iOS 12.0, *)) { \
+          os_signpost_interval_end(log, interval_id, name, "" __VA_ARGS__); \
+        } \
+    })
 
 // See `os_signpost_interval_end`.
 #define gul_os_signpost_interval_emit(log, event_id, name, ...) \
-  os_signpost_interval_emit(log, event_id, name, ##__VA_ARGS__)
+    __extension__({ \
+        if (@available(iOS 12.0, *)) { \
+          os_signpost_interval_end(log, event_id, name, "" __VA_ARGS__); \
+        } \
+    })
 
 // See `_gul_default_signpost_log`.
 #define gul_default_signpost_log() \
   _gul_default_signpost_log()
+
+
+#define _gul_os_signpost_interval_begin(log, interval_id, name, ...) \
+    __extension__({ \
+        if (@available(iOS 12.0, *)) { \
+          os_signpost_interval_begin(log, interval_id, name, "" __VA_ARGS__); \
+        } \
+    })
 
 #else // __has_include(<os/signpost.h>)
 
 // Placeholders for the signpost API methods and types when it's not available.
 
 typedef void gul_os_log_t;
-typedef void gul_os_signpost_id_t;
+typedef uint64_t gul_os_signpost_id_t;
 
-#define gul_os_signpost_id_generate(log)
-
-//#define gul_os_signpost_interval_begin(log, interval_id, name, ...)
+#define gul_os_signpost_interval_begin(log, interval_id, name, ...)
 
 #define gul_os_signpost_interval_end(log, interval_id, name, ...)
 
@@ -56,4 +70,5 @@ typedef void gul_os_signpost_id_t;
 /// @return A default instance of `gul_os_log_t`.
 gul_os_log_t _gul_default_signpost_log(void);
 
-void _gul_os_signpost_interval_begin(gul_os_log_t log, gul_os_signpost_id_t interval_id, const char *name, ...);
+// See `os_signpost_id_generate`.
+gul_os_signpost_id_t gul_os_signpost_id_generate(gul_os_log_t log);

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULSignpostLogger.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULSignpostLogger.h
@@ -19,7 +19,7 @@ typedef os_signpost_id_t gul_os_signpost_id_t;
 
 // See `os_signpost_interval_begin`.
 #define gul_os_signpost_interval_begin(log, interval_id, name, ...) \
-  os_signpost_interval_begin(log, interval_id, name, ##__VA_ARGS__)
+ _gul_os_signpost_interval_begin(log, interval_id, name, ##__VA_ARGS__)
 
 // See `os_signpost_interval_end`.
 #define gul_os_signpost_interval_end(log, interval_id, name, ...) \
@@ -31,7 +31,7 @@ typedef os_signpost_id_t gul_os_signpost_id_t;
 
 // See `_gul_default_signpost_log`.
 #define gul_default_signpost_log() \
-  _gul_default_signpost_log
+  _gul_default_signpost_log()
 
 #else // __has_include(<os/signpost.h>)
 
@@ -42,7 +42,7 @@ typedef void gul_os_signpost_id_t;
 
 #define gul_os_signpost_id_generate(log)
 
-#define gul_os_signpost_interval_begin(log, interval_id, name, ...)
+//#define gul_os_signpost_interval_begin(log, interval_id, name, ...)
 
 #define gul_os_signpost_interval_end(log, interval_id, name, ...)
 
@@ -55,3 +55,5 @@ typedef void gul_os_signpost_id_t;
 /// Returns a default instance of `gul_os_log_t` to be used for signpost logging when available.
 /// @return A default instance of `gul_os_log_t`.
 gul_os_log_t _gul_default_signpost_log(void);
+
+void _gul_os_signpost_interval_begin(gul_os_log_t log, gul_os_signpost_id_t interval_id, const char *name, ...);

--- a/GoogleUtilities/Tests/Unit/Logger/GULSignpostLoggerTests.m
+++ b/GoogleUtilities/Tests/Unit/Logger/GULSignpostLoggerTests.m
@@ -1,0 +1,25 @@
+//
+//  GULSignpostLoggerTests.m
+//  GoogleUtilities-Unit-unit
+//
+//  Created by Maksym Malyhin on 2021-07-07.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "GoogleUtilities/Logger/Public/GoogleUtilities/GULSignpostLogger.h"
+
+@interface GULSignpostLoggerTests : XCTestCase
+
+@end
+
+@implementation GULSignpostLoggerTests
+
+- (void)testSignpostLogs {
+  gul_os_log_t log = gul_default_signpost_log();
+  gul_os_signpost_id_t signpostID = gul_os_signpost_id_generate(log);
+  gul_os_signpost_interval_begin(log, signpostID, "test begin");
+  gul_os_signpost_interval_end(log, signpostID, "test end");
+}
+
+@end


### PR DESCRIPTION
A wrapper for [Signpost API](https://developer.apple.com/documentation/os/logging/recording_performance_data?language=objc) to be used for performance logging in SDKs