### PR TITLE
GULHeartbeatDateStorage: avoid using NSFileCoordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 7.5.1
+- `GULHeartbeatDateStorage`: replace `NSFileCoordinator` with in-process synchronization mechanism. (#51)
 # 7.5.0
 - Bump Promises dependency. (#8334)
 

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '7.5.0'
+  s.version          = '7.5.1'
   s.summary          = 'Google Utilities for Apple platform SDKs'
 
   s.description      = <<-DESC

--- a/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
@@ -86,6 +86,9 @@ NSString *const kGULHeartbeatStorageDirectory = @"Google/FIRApp";
   @synchronized(self.class) {
     NSDictionary *heartbeatDictionary = [self heartbeatDictionaryWithFileURL:self.fileURL];
     NSDate *heartbeatDate = heartbeatDictionary[tag];
+
+    // Validate the value type. If the storage file was corrupted or updated with a different format
+    // by a newer SDK version the value type may be different.
     if (![heartbeatDate isKindOfClass:[NSDate class]]) {
       heartbeatDate = nil;
     }

--- a/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
+++ b/GoogleUtilities/Environment/GULHeartbeatDateStorage.m
@@ -44,7 +44,9 @@ NSString *const kGULHeartbeatStorageDirectory = @"Google/FIRApp";
 }
 
 - (instancetype)initWithFileName:(NSString *)fileName {
-  return [self initWithFileName:fileName queue:dispatch_queue_create("GULHeartbeatDateStorage", DISPATCH_QUEUE_SERIAL)];
+  return [self
+      initWithFileName:fileName
+                 queue:dispatch_queue_create("GULHeartbeatDateStorage", DISPATCH_QUEUE_SERIAL)];
 }
 
 /** Lazy getter for fileURL.
@@ -95,8 +97,7 @@ NSString *const kGULHeartbeatStorageDirectory = @"Google/FIRApp";
   NSError *error;
 
   dispatch_sync(self.queue, ^{
-    NSDictionary *heartbeatDictionary =
-        [self heartbeatDictionaryWithFileURL:self.fileURL];
+    NSDictionary *heartbeatDictionary = [self heartbeatDictionaryWithFileURL:self.fileURL];
     heartbeatDate = heartbeatDictionary[tag];
     if (![heartbeatDate isKindOfClass:[NSDate class]]) {
       heartbeatDate = nil;

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -53,7 +53,8 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 - (void)setUp {
   [super setUp];
 
-  // Clean up before the test in case the cleanup was not completed in previous tests for some reason (e.g. a crash).
+  // Clean up before the test in case the cleanup was not completed in previous tests for some
+  // reason (e.g. a crash).
   [self cleanupStorageDir];
 
   self.storage = [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];
@@ -321,7 +322,7 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 
   // Wait until all storage operations completed.
   dispatch_barrier_sync(concurrentQueue, ^{
-  });
+                        });
 }
 
 - (void)testConcurrentReadWritesToTheSameFileFromDifferentInstances {
@@ -349,7 +350,7 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 
   // Wait until all storage operations completed.
   dispatch_barrier_sync(concurrentQueue, ^{
-  });
+                        });
 }
 
 #pragma mark - Version Compatibility (#36)

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -307,7 +307,8 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 #pragma mark - Concurrency tests
 
 - (void)testConcurrentReadWriteWithSingleInstance {
-  dispatch_queue_t concurrentQueue = dispatch_queue_create("testConcurrentReadWriteToTheSameFileFromDifferentInstances", DISPATCH_QUEUE_CONCURRENT);
+  dispatch_queue_t concurrentQueue = dispatch_queue_create(
+      "testConcurrentReadWriteToTheSameFileFromDifferentInstances", DISPATCH_QUEUE_CONCURRENT);
 
   NSString *tag = self.name;
   NSUInteger attemptsCount = 50;
@@ -326,16 +327,20 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 }
 
 - (void)testConcurrentReadWritesToTheSameFileFromDifferentInstances {
-  dispatch_queue_t concurrentQueue = dispatch_queue_create("testConcurrentReadWriteToTheSameFileFromDifferentInstances", DISPATCH_QUEUE_CONCURRENT);
+  dispatch_queue_t concurrentQueue = dispatch_queue_create(
+      "testConcurrentReadWriteToTheSameFileFromDifferentInstances", DISPATCH_QUEUE_CONCURRENT);
 
   NSString *tag = self.name;
 
-  GULHeartbeatDateStorage *storage1 = [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];
-  GULHeartbeatDateStorage *storage2 = [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];
+  GULHeartbeatDateStorage *storage1 =
+      [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];
+  GULHeartbeatDateStorage *storage2 =
+      [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];
 
   NSUInteger attemptsCount = 50;
 
-  XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%@-1", self.name]];
+  XCTestExpectation *expectation1 =
+      [self expectationWithDescription:[NSString stringWithFormat:@"%@-1", self.name]];
   expectation1.expectedFulfillmentCount = attemptsCount;
 
   for (NSUInteger i = 0; i < attemptsCount; i++) {
@@ -345,7 +350,8 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
     });
   }
 
-  XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%@-2", self.name]];
+  XCTestExpectation *expectation2 =
+      [self expectationWithDescription:[NSString stringWithFormat:@"%@-2", self.name]];
   expectation2.expectedFulfillmentCount = attemptsCount;
   for (NSUInteger i = 0; i < attemptsCount; i++) {
     dispatch_async(concurrentQueue, ^{
@@ -494,7 +500,9 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
   [storage setHearbeatDate:date forTag:tag];
 
   // Assert that the file was not corrupted by concurrent access.
-  // NOTE: With the current synchronization model we cannot expect the read date to be equal the date just set because another date may be set from another thread before read is performed. Prevent the read/modify/write data race is currently the storage clients responsibility.
+  // NOTE: With the current synchronization model we cannot expect the read date to be equal the
+  // date just set because another date may be set from another thread before read is performed.
+  // Prevent the read/modify/write data race is currently the storage clients responsibility.
   XCTAssertNotNil([storage heartbeatDateForTag:tag]);
 }
 

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -53,6 +53,9 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 - (void)setUp {
   [super setUp];
 
+  // Clean up before the test in case the cleanup was not completed in previous tests for some reason (e.g. a crash).
+  [self cleanupStorageDir];
+
   self.storage = [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];
   [self assertInitializationDoesNotAccessFileSystem];
 }
@@ -60,9 +63,7 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 - (void)tearDown {
   [super tearDown];
 
-  // Removes the Heartbeat Storage Directory if it exists.
-  NSURL *directoryURL = [self pathURLForDirectory:kGULHeartbeatStorageDirectory];
-  [[NSFileManager defaultManager] removeItemAtURL:directoryURL error:nil];
+  [self cleanupStorageDir];
 
   self.storage = nil;
 }
@@ -501,6 +502,12 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
   // date just set because another date may be set from another thread before read is performed.
   // Prevent the read/modify/write data race is currently the storage clients responsibility.
   XCTAssertNotNil([storage heartbeatDateForTag:tag]);
+}
+
+- (void)cleanupStorageDir {
+  // Removes the Heartbeat Storage Directory if it exists.
+  NSURL *directoryURL = [self pathURLForDirectory:kGULHeartbeatStorageDirectory];
+  [[NSFileManager defaultManager] removeItemAtURL:directoryURL error:nil];
 }
 
 @end

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -313,17 +313,15 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 
   NSUInteger attemptsCount = 50;
 
-  XCTestExpectation *expectation = [self expectationWithDescription:self.name];
-  expectation.expectedFulfillmentCount = attemptsCount;
-
   for (NSUInteger i = 0; i < attemptsCount; i++) {
     dispatch_async(concurrentQueue, ^{
       [self assertWriteAndReadNoFileCorruption:self.storage];
-      [expectation fulfill];
     });
   }
 
-  [self waitForExpectations:@[ expectation ] timeout:1];
+  // Wait until all storage operations completed.
+  dispatch_barrier_sync(concurrentQueue, ^{
+  });
 }
 
 - (void)testConcurrentReadWritesToTheSameFileFromDifferentInstances {
@@ -337,28 +335,21 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 
   NSUInteger attemptsCount = 50;
 
-  XCTestExpectation *expectation1 =
-      [self expectationWithDescription:[NSString stringWithFormat:@"%@-1", self.name]];
-  expectation1.expectedFulfillmentCount = attemptsCount;
-
   for (NSUInteger i = 0; i < attemptsCount; i++) {
     dispatch_async(concurrentQueue, ^{
       [self assertWriteAndReadNoFileCorruption:storage1];
-      [expectation1 fulfill];
     });
   }
 
-  XCTestExpectation *expectation2 =
-      [self expectationWithDescription:[NSString stringWithFormat:@"%@-2", self.name]];
-  expectation2.expectedFulfillmentCount = attemptsCount;
   for (NSUInteger i = 0; i < attemptsCount; i++) {
     dispatch_async(concurrentQueue, ^{
       [self assertWriteAndReadNoFileCorruption:storage2];
-      [expectation2 fulfill];
     });
   }
 
-  [self waitForExpectations:@[ expectation1, expectation2 ] timeout:1];
+  // Wait until all storage operations completed.
+  dispatch_barrier_sync(concurrentQueue, ^{
+  });
 }
 
 #pragma mark - Version Compatibility (#36)

--- a/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULHeartbeatDateStorageTest.m
@@ -310,7 +310,6 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
   dispatch_queue_t concurrentQueue = dispatch_queue_create(
       "testConcurrentReadWriteToTheSameFileFromDifferentInstances", DISPATCH_QUEUE_CONCURRENT);
 
-  NSString *tag = self.name;
   NSUInteger attemptsCount = 50;
 
   XCTestExpectation *expectation = [self expectationWithDescription:self.name];
@@ -329,8 +328,6 @@ static NSString *const kTestFileName = @"GULStorageHeartbeatTestFile";
 - (void)testConcurrentReadWritesToTheSameFileFromDifferentInstances {
   dispatch_queue_t concurrentQueue = dispatch_queue_create(
       "testConcurrentReadWriteToTheSameFileFromDifferentInstances", DISPATCH_QUEUE_CONCURRENT);
-
-  NSString *tag = self.name;
 
   GULHeartbeatDateStorage *storage1 =
       [[GULHeartbeatDateStorage alloc] initWithFileName:kTestFileName];


### PR DESCRIPTION
Related to https://github.com/firebase/firebase-ios-sdk/issues/8524

[NSFileCoordinator](https://developer.apple.com/documentation/foundation/nsfilecoordinator?language=objc) behaves unexpectedly (crashes) on some macOS versions. 

`NSFileCoordinator` was used to prevent concurrent access to a storage file from different processes and threads. Initially `GULHeartbeatDateStorage` was designed with intention to share the same heartbeat between an app and its extensions which implies access to a file from different processes. But the sharing was never implemented and there are not immediate plans to do it. It means that `NSFileCoordinator` can be safely replaced by other in-process synchronization mechanisms.

Note that `GULHeartbeatDateStorage` API is currently susceptible to read-modify-write data race (two clients can read the same value one after another, do calculations based on it and write an updated value, in this case the first written value will be lost and the second value will be calculated based on the outdated initial one). Fix of this data race is out of scope of this PR, because:
- the fix requires API changes which implies clients updates which means that old clients will keep crashing
- the data race is not a regression unlike the crashes