### PR TITLE
Set the class of a swizzled object back to its original class upon deallocation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+# 7.5.2
+- Do not dispose a swizzler's generated class when using the Zombies instrument. (#8321)
+
 # 7.5.1
 - `GULHeartbeatDateStorage`: replace `NSFileCoordinator` with in-process synchronization mechanism. (#51)
+
 # 7.5.0
 - Bump Promises dependency. (#8334)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 7.5.2
-- Do not dispose a swizzler's generated class when using the Zombies instrument. (#8321)
+- Set the class of a swizzled object back to its original class upon deallocation. (#8321)
 
 # 7.5.1
 - `GULHeartbeatDateStorage`: replace `NSFileCoordinator` with in-process synchronization mechanism. (#51)

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -163,16 +163,8 @@
   if (_generatedClass) {
     if (_swizzledObject == nil) {
       // The swizzled object has been deallocated already, so the generated class can be disposed
-      // now (unless the Zombies instrument is enabled).
-
-      // When the Zombies instrument is enabled, a zombie is created for the
-      // swizzled object upon deallocation. Because this zombie subclasses
-      // the generated class, the swizzler should not dispose it.
-      NSDictionary *environment = [[NSProcessInfo processInfo] environment];
-      BOOL zombiesEnabled = [[environment objectForKey:@"NSZombieEnabled"] boolValue];
-      if (!zombiesEnabled) {
+      // now.
         objc_disposeClassPair(_generatedClass);
-      }
       return;
     }
 

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -164,7 +164,7 @@
     if (_swizzledObject == nil) {
       // The swizzled object has been deallocated already, so the generated class can be disposed
       // now.
-        objc_disposeClassPair(_generatedClass);
+      objc_disposeClassPair(_generatedClass);
       return;
     }
 

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -163,8 +163,16 @@
   if (_generatedClass) {
     if (_swizzledObject == nil) {
       // The swizzled object has been deallocated already, so the generated class can be disposed
-      // now.
-      objc_disposeClassPair(_generatedClass);
+      // now (unless the Zombies instrument is enabled).
+
+      // When the Zombies instrument is enabled, a zombie is created for the
+      // swizzled object upon deallocation. Because this zombie subclasses
+      // the generated class, the swizzler should not dispose it.
+      NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+      BOOL zombiesEnabled = [[environment objectForKey:@"NSZombieEnabled"] boolValue];
+      if (!zombiesEnabled) {
+        objc_disposeClassPair(_generatedClass);
+      }
       return;
     }
 

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -138,6 +138,5 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 #pragma clang diagnostic pop
   }
 }
-}
 
 @end

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -29,7 +29,7 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 + (void)copyDonorSelectorsUsingObjectSwizzler:(GULObjectSwizzler *)objectSwizzler {
   [objectSwizzler copySelector:@selector(gul_objectSwizzler) fromClass:self isClassSelector:NO];
   [objectSwizzler copySelector:@selector(gul_class) fromClass:self isClassSelector:NO];
-  // ARC does not allow `@selector(dealloc)`.
+  // ARC does not allow `@selector(dealloc)` so `NSSelectorFromString(@"dealloc")` is used instead.
   [objectSwizzler copySelector:NSSelectorFromString(kGULSwizzlerDeallocSEL)
                      fromClass:self
                isClassSelector:NO];
@@ -134,6 +134,8 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
     // Call the original class's `dealloc` implementation.
+    // ARC does not allow `@selector(dealloc)` so `NSSelectorFromString(@"dealloc")` is used
+    // instead.
     [self performSelector:NSSelectorFromString(kGULSwizzlerDeallocSEL)];
 #pragma clang diagnostic pop
   }

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -66,49 +66,49 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 }
 
 - (void)dealloc {
-  // The goal of this `dealloc` is to switch the swizzled object's class to 
-  // the original object's class before complete deallocation. 
+  // The goal of this `dealloc` is to switch the swizzled object's class to
+  // the original object's class before complete deallocation.
   //
   // Additional Context:
-  // 
+  //
   // - Problem
   //   When the Zombies instrument is enabled, a zombie is created as a subclass
   //   of the deallocating object. In the case of a deallocated swizzled object,
-  //   the zombie will subclass the swizzled object's generated class. This 
+  //   the zombie will subclass the swizzled object's generated class. This
   //   leads to a crash that occurs when the generated class is later disposed
-  //   by the swizzler (see `dealloc` in `GULObjectSwizzler.m`). 
-  //   
-  //   This problem only occurs when the Zombies instrument is enabled 
+  //   by the swizzler (see `dealloc` in `GULObjectSwizzler.m`).
+  //
+  //   This problem only occurs when the Zombies instrument is enabled
   //   for the above reasoning. See firebase-ios-sdk/issues/8321
   //
   // - Solution
   //   The solution is to switch the swizzled object's class to the original
-  //   object's class before complete deallocation. This way, when the 
-  //   Zombies instrument is enabled, a zombie will be created using the 
+  //   object's class before complete deallocation. This way, when the
+  //   Zombies instrument is enabled, a zombie will be created using the
   //   original class. This allows `GULObjectSwizzler` to safely dispose its
-  //   generated classes. This approach yields the following order of 
+  //   generated classes. This approach yields the following order of
   //   deallocation when a swizzled object's reference count goes to 0.
   //   - Order of deallocation:
   //     1. Swizzled object (generated class)
   //     2. Original object (original class) and its super classes
   //     3. Swizzler
 
-  // Create a local autorelease pool to avoid retaining the swizzler past the 
+  // Create a local autorelease pool to avoid retaining the swizzler past the
   // swizzled object's deallocation.
-  // 
+  //
   // Additional Context:
   //
-  // - Without the local autorelease pool, a retain cycle is formed  
-  //   when `[self gul_class]` is called because the call strongly references 
-  //   the swizzler and the swizzler references the swizzled object. 
-  //   Note, although the swizzler has a `weak` reference to the 
-  //   swizzled object, this `weak` reference does not seem to work as intended 
+  // - Without the local autorelease pool, a retain cycle is formed
+  //   when `[self gul_class]` is called because the call strongly references
+  //   the swizzler and the swizzler references the swizzled object.
+  //   Note, although the swizzler has a `weak` reference to the
+  //   swizzled object, this `weak` reference does not seem to work as intended
   //   when the logic is performed in `dealloc`.
   @autoreleasepool {
     // Retrieve the original class that the swizzler swizzled.
     Class originalClass = [[self gul_class] superclass];
-    
-    // In some cases, it is possible for the `originalClass` to be 
+
+    // In some cases, it is possible for the `originalClass` to be
     // nil (i.e. the swizzled object does not have not have a superclass).
     if (!originalClass) {
       return;
@@ -124,7 +124,7 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
     //
     // Additional context:
     //
-    // A root class is a class that does not have a superclass. Foundation has 
+    // A root class is a class that does not have a superclass. Foundation has
     // two root classes: `NSObject` and `NSProxy`.
     BOOL classIsARootClass = ![self superclass] || [self isProxy];
     if (classIsARootClass) {
@@ -136,8 +136,8 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
     // Call the original class's `dealloc` implementation.
     [self performSelector:NSSelectorFromString(kGULSwizzlerDeallocSEL)];
 #pragma clang diagnostic pop
-    }
   }
+}
 }
 
 @end

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -66,17 +66,22 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 }
 
 - (void)dealloc {
-  // Set the generated class to the original class.
-  Class originalClass = [[self gul_class] superclass];
-  object_setClass(self, originalClass);
+  @autoreleasepool {
+    // Set the generated class to the original class.
+    Class originalClass = [[self gul_class] superclass];
+    if (![originalClass superclass] || [self isProxy]) {
+      return;
+    }
 
-  // `self` is now the original class.
+    // `self` is now the original class.
+    object_setClass(self, originalClass);
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-  // Call the original class's `dealloc` implementation.
-  [self performSelector:NSSelectorFromString(kGULSwizzlerDeallocSEL)];
+    // Call the original class's `dealloc` implementation.
+    [self performSelector:NSSelectorFromString(kGULSwizzlerDeallocSEL)];
 #pragma clang diagnostic pop
+  }
 }
 
 @end


### PR DESCRIPTION
~~This just avoids disposing the swizzler's generated classes when zombies is enabled.~~

- [x] detailed explanation of what we do and why in the comments
- [ ] tests?
- [ ] document possible edge cases when it may not work as expected...

Fix [#8321](https://github.com/firebase/firebase-ios-sdk/issues/8321)