### PR TITLE
Revert "Set the class of a swizzled object back to its original class upon deallocation."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
-# 7.5.2
-- Set the class of a swizzled object back to its original class upon deallocation. (#8321)
-
 # 7.5.1
 - `GULHeartbeatDateStorage`: replace `NSFileCoordinator` with in-process synchronization mechanism. (#51)
-
 # 7.5.0
 - Bump Promises dependency. (#8334)
 

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -18,7 +18,6 @@
 #import "GoogleUtilities/ISASwizzler/Public/GoogleUtilities/GULSwizzledObject.h"
 
 NSString *kGULSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
-static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 
 @interface GULSwizzledObject ()
 
@@ -29,10 +28,7 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 + (void)copyDonorSelectorsUsingObjectSwizzler:(GULObjectSwizzler *)objectSwizzler {
   [objectSwizzler copySelector:@selector(gul_objectSwizzler) fromClass:self isClassSelector:NO];
   [objectSwizzler copySelector:@selector(gul_class) fromClass:self isClassSelector:NO];
-  // ARC does not allow `@selector(dealloc)` so `NSSelectorFromString(@"dealloc")` is used instead.
-  [objectSwizzler copySelector:NSSelectorFromString(kGULSwizzlerDeallocSEL)
-                     fromClass:self
-               isClassSelector:NO];
+
   // This is needed because NSProxy objects usually override -[NSObjectProtocol respondsToSelector:]
   // and ask this question to the underlying object. Since we don't swizzle the underlying object
   // but swizzle the proxy, when someone calls -[NSObjectProtocol respondsToSelector:] on the proxy,
@@ -63,82 +59,6 @@ static NSString *const kGULSwizzlerDeallocSEL = @"dealloc";
 - (BOOL)respondsToSelector:(SEL)aSelector {
   Class gulClass = [[self gul_objectSwizzler] generatedClass];
   return [gulClass instancesRespondToSelector:aSelector] || [super respondsToSelector:aSelector];
-}
-
-- (void)dealloc {
-  // The goal of this `dealloc` is to switch the swizzled object's class to
-  // the original object's class before complete deallocation.
-  //
-  // Additional Context:
-  //
-  // - Problem
-  //   When the Zombies instrument is enabled, a zombie is created as a subclass
-  //   of the deallocating object. In the case of a deallocated swizzled object,
-  //   the zombie will subclass the swizzled object's generated class. This
-  //   leads to a crash that occurs when the generated class is later disposed
-  //   by the swizzler (see `dealloc` in `GULObjectSwizzler.m`).
-  //
-  //   This problem only occurs when the Zombies instrument is enabled
-  //   for the above reasoning. See firebase-ios-sdk/issues/8321
-  //
-  // - Solution
-  //   The solution is to switch the swizzled object's class to the original
-  //   object's class before complete deallocation. This way, when the
-  //   Zombies instrument is enabled, a zombie will be created using the
-  //   original class. This allows `GULObjectSwizzler` to safely dispose its
-  //   generated classes. This approach yields the following order of
-  //   deallocation when a swizzled object's reference count goes to 0.
-  //   - Order of deallocation:
-  //     1. Swizzled object (generated class)
-  //     2. Original object (original class) and its super classes
-  //     3. Swizzler
-
-  // Create a local autorelease pool to avoid retaining the swizzler past the
-  // swizzled object's deallocation.
-  //
-  // Additional Context:
-  //
-  // - Without the local autorelease pool, a retain cycle is formed
-  //   when `[self gul_class]` is called because the call strongly references
-  //   the swizzler and the swizzler references the swizzled object.
-  //   Note, although the swizzler has a `weak` reference to the
-  //   swizzled object, this `weak` reference does not seem to work as intended
-  //   when the logic is performed in `dealloc`.
-  @autoreleasepool {
-    // Retrieve the original class that the swizzler swizzled.
-    Class originalClass = [[self gul_class] superclass];
-
-    // In some cases, it is possible for the `originalClass` to be
-    // nil (i.e. the swizzled object does not have not have a superclass).
-    if (!originalClass) {
-      return;
-    }
-
-    // Set the swizzled object's class to the original class.
-    object_setClass(self, originalClass);
-
-    // Note: `self` is now the original class.
-
-    // If `self` is now a root class or an object inheriting from `NSProxy`, we
-    // cannot call `dealloc` on it and should return now.
-    //
-    // Additional context:
-    //
-    // A root class is a class that does not have a superclass. Foundation has
-    // two root classes: `NSObject` and `NSProxy`.
-    BOOL classIsARootClass = ![self superclass] || [self isProxy];
-    if (classIsARootClass) {
-      return;
-    }
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    // Call the original class's `dealloc` implementation.
-    // ARC does not allow `@selector(dealloc)` so `NSSelectorFromString(@"dealloc")` is used
-    // instead.
-    [self performSelector:NSSelectorFromString(kGULSwizzlerDeallocSEL)];
-#pragma clang diagnostic pop
-  }
 }
 
 @end


### PR DESCRIPTION
Reverts google/GoogleUtilities#52

Order of operations:
- [ ] Merge this revert into `main`
- [ ] Merge #57 (previous fix) into `main` 
- [ ] Retag `CocoaPods-8.5.1` to `main`'s latest commit 