### PR TITLE
Don't dispose generated classes when Zombies is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 7.5.2
-- Set the class of a swizzled object back to its original class upon deallocation. (#8321)
+- Do not dispose a swizzler's generated class when using the Zombies instrument. (#8321)
 
 # 7.5.1
 - `GULHeartbeatDateStorage`: replace `NSFileCoordinator` with in-process synchronization mechanism. (#51)

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -163,8 +163,16 @@
   if (_generatedClass) {
     if (_swizzledObject == nil) {
       // The swizzled object has been deallocated already, so the generated class can be disposed
-      // now.
-      objc_disposeClassPair(_generatedClass);
+      // now (unless the Zombies instrument is enabled).
+
+      // When the Zombies instrument is enabled, a zombie is created for the
+      // swizzled object upon deallocation. Because this zombie subclasses
+      // the generated class, the swizzler should not dispose it.
+      NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+      BOOL zombiesEnabled = [[environment objectForKey:@"NSZombieEnabled"] boolValue];
+      if (!zombiesEnabled) {
+        objc_disposeClassPair(_generatedClass);
+      }
       return;
     }
 


### PR DESCRIPTION
This is the original fix that checks the env vars for Zombies being enabled. If Zombies is enabled, then the generated class is not disposed

Fix https://github.com/firebase/firebase-ios-sdk/issues/8321