### PR TITLE
Update missing clang-format instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ GitHub Actions will verify that any code changes are done in a style compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@12
+brew install clang-format@13
 brew install mint
 ```
 


### PR DESCRIPTION
This was missed in #60.