### PR TITLE
[Environment] Update `deploymentType` API to fall back to `unknown` instead of `cocoapods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # 7.8.0
+- Update `+ [GULAppEnvironmentUtil deploymentType]` API to fall back to 
+  `unknown` instead of `cocoapods`. (#79)
 - Prevent keychain access from prompting user for permissions on macOS. Using
   GoogleUtilities's keychain wrapper API **on macOS** now requires that the
   target be signed with a provisioning profile that has the Keychain Sharing

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -323,8 +323,10 @@ static BOOL HasEmbeddedMobileProvision() {
   NSString *deploymentType = @"carthage";
 #elif FIREBASE_BUILD_ZIP_FILE
   NSString *deploymentType = @"zip";
-#else
+#elif COCOAPODS
   NSString *deploymentType = @"cocoapods";
+#else
+  NSString *deploymentType = @"unknown";
 #endif
 
   return deploymentType;

--- a/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
@@ -70,8 +70,10 @@
   NSString *deploymentType = @"carthage";
 #elif FIREBASE_BUILD_ZIP_FILE
   NSString *deploymentType = @"zip";
-#else
+#elif COCOAPODS
   NSString *deploymentType = @"cocoapods";
+#else
+  NSString *deploymentType = @"unknown";
 #endif
 
   XCTAssertEqualObjects([GULAppEnvironmentUtil deploymentType], deploymentType);


### PR DESCRIPTION
### Context
Up until this PR, the `+ [GULAppEnvironmentUtil deploymentType]` API has
returned `cocoapods` for non-SwiftPM, non-Carthage, and non-Zip builds. While
such builds can be built via CocoaPods, defaulting to `cocoapods` is not very
precise for cases where the framework is built using other build types (such
as in piper).
