### PR TITLE
Add missing test of weak variable

### DIFF
--- a/GoogleUtilities/Tests/Unit/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Tests/Unit/Swizzler/GULObjectSwizzlerTest.m
@@ -357,6 +357,7 @@
                                      value:nil
                                association:GUL_ASSOCIATION_RETAIN];
   }
+  XCTAssertNil(weakSwizzler);
 
   // Clean up.
   objc_disposeClassPair(generatedClass);


### PR DESCRIPTION
Follow up to #84 

It's still a mystery about why deleting the weak variable causes the test to fail with

```
objc[12242]: objc_disposeClassPair: class 'fir_18AC4DEE-8462-4B19-8F73-9675818BD98F_GULProxy' still has subclasses, including 'gul_test_0x600000c8c0d0_fir_18AC4DEE-8462-4B19-8F73-9675818BD98F_GULProxy'!
```

but this change makes the test consistent with the other tests and actually uses the declared `weakSwizzler` variable.