### PR TITLE
Add new App Environment Util for appleDevicePlatform

### DIFF
--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
@@ -52,6 +52,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return An Apple platform. Possible values "ios", "tvos", "macos", "watchos", "maccatalyst".
 + (NSString *)applePlatform;
 
+/// @return An Apple Device platform. Same possible values as `applePlatform`, with the addition of "ipados".
++ (NSString *)appleDevicePlatform;
+
 /// @return The way the library was added to the app, e.g. "swiftpm", "cocoapods", etc.
 + (NSString *)deploymentType;
 

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
@@ -52,7 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return An Apple platform. Possible values "ios", "tvos", "macos", "watchos", "maccatalyst".
 + (NSString *)applePlatform;
 
-/// @return An Apple Device platform. Same possible values as `applePlatform`, with the addition of "ipados".
+/// @return An Apple Device platform. Same possible values as `applePlatform`, with the addition of
+/// "ipados".
 + (NSString *)appleDevicePlatform;
 
 /// @return The way the library was added to the app, e.g. "swiftpm", "cocoapods", etc.

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -316,6 +316,22 @@ static BOOL HasEmbeddedMobileProvision() {
   return applePlatform;
 }
 
++ (NSString *)appleDevicePlatform {
+  NSString* firebasePlatform = [GULAppEnvironmentUtil applePlatform];
+#if TARGET_OS_IOS
+  // This check is necessary because iOS-only apps running on iPad
+  // will report UIUserInterfaceIdiomPhone via UI_USER_INTERFACE_IDIOM().
+  if ([firebasePlatform isEqualToString:@"ios"] &&
+      ([[UIDevice currentDevice].model.lowercaseString containsString:@"ipad"] ||
+       [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)) {
+    return @"ipados";
+  }
+#endif
+
+  return firebasePlatform;
+}
+
+
 + (NSString *)deploymentType {
 #if SWIFT_PACKAGE
   NSString *deploymentType = @"swiftpm";

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -331,7 +331,6 @@ static BOOL HasEmbeddedMobileProvision() {
   return firebasePlatform;
 }
 
-
 + (NSString *)deploymentType {
 #if SWIFT_PACKAGE
   NSString *deploymentType = @"swiftpm";

--- a/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
@@ -103,4 +103,33 @@
   XCTAssertEqualObjects([GULAppEnvironmentUtil applePlatform], expectedPlatform);
 }
 
+- (void)testAppleDevicePlatform {
+  // When a Catalyst app is run on macOS then both `TARGET_OS_MACCATALYST` and `TARGET_OS_IOS` are
+  // `true`.
+#if TARGET_OS_MACCATALYST
+  NSString *expectedPlatform = @"maccatalyst";
+#elif TARGET_OS_IOS
+  NSString *expectedPlatform = @"ios";
+
+  if ([[UIDevice currentDevice].model.lowercaseString containsString:@"ipad"] ||
+      [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    expectedPlatform = @"ipados";
+  }
+#endif  // TARGET_OS_MACCATALYST
+
+#if TARGET_OS_TV
+  NSString *expectedPlatform = @"tvos";
+#endif  // TARGET_OS_TV
+
+#if TARGET_OS_OSX
+  NSString *expectedPlatform = @"macos";
+#endif  // TARGET_OS_OSX
+
+#if TARGET_OS_WATCH
+  NSString *expectedPlatform = @"watchos";
+#endif  // TARGET_OS_WATCH
+
+  XCTAssertEqualObjects([GULAppEnvironmentUtil appleDevicePlatform], expectedPlatform);
+}
+
 @end


### PR DESCRIPTION
Crashlytics uses this code to display and filter events on the dashboard: 
https://github.com/firebase/firebase-ios-sdk/blob/master/Crashlytics/Crashlytics/Components/FIRCLSApplication.m#L54

We're hoping to move this code into GoogleUtilities so it can be shared across Crashlytics and Sessions.

![image](https://user-images.githubusercontent.com/555046/196535222-26ab1410-fa5a-4058-933e-ae04e2bd8eab.png)
