### PR TITLE
Add deviceSimulatorModel to GULAppEnvironmentUtil

### DIFF
--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
@@ -35,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The current device model. Returns an empty string if device model cannot be retrieved.
 + (nullable NSString *)deviceModel;
 
+/// The current device model, with simulator-specific values. Returns an empty string if device model cannot be retrieved.
++ (nullable NSString *)deviceSimulatorModel;
+
 /// The current operating system version. Returns an empty string if the system version cannot be
 /// retrieved.
 + (NSString *)systemVersion;

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
@@ -35,7 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The current device model. Returns an empty string if device model cannot be retrieved.
 + (nullable NSString *)deviceModel;
 
-/// The current device model, with simulator-specific values. Returns an empty string if device model cannot be retrieved.
+/// The current device model, with simulator-specific values. Returns an empty string if device
+/// model cannot be retrieved.
 + (nullable NSString *)deviceSimulatorModel;
 
 /// The current operating system version. Returns an empty string if the system version cannot be

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -25,6 +25,8 @@
 #import <UIKit/UIKit.h>
 #endif
 
+#define FIRCLS_HOST_SYSCTL_BUFFER_SIZE (128)
+
 /// The encryption info struct and constants are missing from the iPhoneSimulator SDK, but not from
 /// the iPhoneOS or Mac OS X SDKs. Since one doesn't ever ship a Simulator binary, we'll just
 /// provide the definitions here.
@@ -209,6 +211,21 @@ static BOOL HasEmbeddedMobileProvision() {
   return NO;
 }
 
++ (NSString *)getSysctlEntry:(const char *)sysctlKey {
+  static NSString *entryValue;
+  size_t size;
+  sysctlbyname(sysctlKey, NULL, &size, NULL, 0);
+  if (size > 0) {
+    char *entryValueCStr = malloc(size);
+    sysctlbyname(sysctlKey, entryValueCStr, &size, NULL, 0);
+    entryValue = [NSString stringWithCString:entryValueCStr encoding:NSUTF8StringEncoding];
+    free(entryValueCStr);
+    return entryValue;
+  } else {
+    return nil;
+  }
+}
+
 + (NSString *)deviceModel {
   static dispatch_once_t once;
   static NSString *deviceModel;
@@ -217,14 +234,8 @@ static BOOL HasEmbeddedMobileProvision() {
   dispatch_once(&once, ^{
     // The `uname` function only returns x86_64 for Macs. Use `sysctlbyname` instead, but fall back
     // to the `uname` function if it fails.
-    size_t size;
-    sysctlbyname("hw.model", NULL, &size, NULL, 0);
-    if (size > 0) {
-      char *machine = malloc(size);
-      sysctlbyname("hw.model", machine, &size, NULL, 0);
-      deviceModel = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
-      free(machine);
-    } else {
+    deviceModel = [GULAppEnvironmentUtil getSysctlEntry:"hw.model"];
+    if (deviceModel.length == 0) {
       struct utsname systemInfo;
       if (uname(&systemInfo) == 0) {
         deviceModel = [NSString stringWithUTF8String:systemInfo.machine];
@@ -240,6 +251,36 @@ static BOOL HasEmbeddedMobileProvision() {
   });
 #endif  // TARGET_OS_OSX || TARGET_OS_MACCATALYST
   return deviceModel;
+}
+
++ (NSString *)deviceSimulatorModel {
+  NSString *model = nil;
+
+#if TARGET_OS_SIMULATOR
+#if TARGET_OS_WATCH
+  model = @"watchOS Simulator";
+#elif TARGET_OS_TV
+  model = @"tvOS Simulator";
+#elif TARGET_OS_IPHONE
+  switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
+    case UIUserInterfaceIdiomPhone:
+      model = @"iOS Simulator (iPhone)";
+      break;
+    case UIUserInterfaceIdiomPad:
+      model = @"iOS Simulator (iPad)";
+      break;
+    default:
+      model = @"iOS Simulator (Unknown)";
+      break;
+  }
+#endif
+#elif TARGET_OS_EMBEDDED
+  model = [GULAppEnvironmentUtil getSysctlEntry:"hw.machine"];
+#else
+  model = [GULAppEnvironmentUtil getSysctlEntry:"hw.model"];
+#endif
+
+  return model;
 }
 
 + (NSString *)systemVersion {

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -25,8 +25,6 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#define FIRCLS_HOST_SYSCTL_BUFFER_SIZE (128)
-
 /// The encryption info struct and constants are missing from the iPhoneSimulator SDK, but not from
 /// the iPhoneOS or Mac OS X SDKs. Since one doesn't ever ship a Simulator binary, we'll just
 /// provide the definitions here.
@@ -254,31 +252,34 @@ static BOOL HasEmbeddedMobileProvision() {
 }
 
 + (NSString *)deviceSimulatorModel {
-  NSString *model = nil;
+  static dispatch_once_t once;
+  static NSString *model = nil;
 
+  dispatch_once(&once, ^{
 #if TARGET_OS_SIMULATOR
 #if TARGET_OS_WATCH
-  model = @"watchOS Simulator";
+    model = @"watchOS Simulator";
 #elif TARGET_OS_TV
-  model = @"tvOS Simulator";
+    model = @"tvOS Simulator";
 #elif TARGET_OS_IPHONE
-  switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
-    case UIUserInterfaceIdiomPhone:
-      model = @"iOS Simulator (iPhone)";
-      break;
-    case UIUserInterfaceIdiomPad:
-      model = @"iOS Simulator (iPad)";
-      break;
-    default:
-      model = @"iOS Simulator (Unknown)";
-      break;
-  }
+    switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
+      case UIUserInterfaceIdiomPhone:
+        model = @"iOS Simulator (iPhone)";
+        break;
+      case UIUserInterfaceIdiomPad:
+        model = @"iOS Simulator (iPad)";
+        break;
+      default:
+        model = @"iOS Simulator (Unknown)";
+        break;
+    }
 #endif
 #elif TARGET_OS_EMBEDDED
-  model = [GULAppEnvironmentUtil getSysctlEntry:"hw.machine"];
+    model = [GULAppEnvironmentUtil getSysctlEntry:"hw.machine"];
 #else
-  model = [GULAppEnvironmentUtil getSysctlEntry:"hw.model"];
+    model = [GULAppEnvironmentUtil getSysctlEntry:"hw.model"];
 #endif
+  });
 
   return model;
 }


### PR DESCRIPTION
Crashlytics has an important function that returns the device model: [FIRCLSFABHost.m](https://github.com/firebase/firebase-ios-sdk/blob/master/Crashlytics/Shared/FIRCLSFABHost.m#L91-L119)

The main purpose of this PR is to share that code with the new FirebaseSessions SDK for the purposes of filtering events consistently between the 2 products, similar to https://github.com/google/GoogleUtilities/pull/89.

There are a few differences between this code and the existing `[GULAppEnvironmentUtil deviceModel]`:

### 1) The new deviceSimulatorModel has specific values for simulators. 

For example, running both methods on a simulator yields the following results:

```
GULAppEnvironmentUtil.deviceModel: arm64
GULAppEnvironmentUtil.deviceSimulatorModel: iOS Simulator (iPhone)
```

### 2) The new deviceSimulatorModel uses `sysctlbyname(hw.machine...)` instead of `uname(...)` on non-macOS platforms.

Similar to other cases, we're very sensitive to change anything about the Crashlytics implementation, as there are downstream effects that will impact customers, for example changing how issue device breakdowns work:

![Screen Shot 2022-10-27 at 11 40 17 AM](https://user-images.githubusercontent.com/555046/198335536-35d66218-5ec0-4c8e-a8a8-dc7532a3ae66.png)

As such, I'm keenly interested if there is any difference between `sysctlbyname(hw.machine...)` instead of `uname(...)`. If so, we'd want this new method, `deviceSimulatorModel`, to use `sysctlbyname(hw.machine...)`


# Naming
I named it `deviceSimulatorModel`, but it might not be the clearest name.

 - `deviceWithSimulatorModel`
 - `deviceModelWithSimulator`
 - `deviceAndSimulatorModel`