### PR TITLE
Add Network Utilities to GoogleUtilities

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -43,7 +43,6 @@ other Google CocoaPods. They're not intended for direct public usage.
       'Security'
     ]
     es.ios.frameworks = [
-      'SCNetworkReachability',
       'CoreTelephony',
     ]
   end

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -42,6 +42,10 @@ other Google CocoaPods. They're not intended for direct public usage.
     es.frameworks = [
       'Security'
     ]
+    es.ios.frameworks = [
+      'SCNetworkReachability',
+      'CoreTelephony',
+    ]
   end
 
   s.subspec 'Logger' do |ls|

--- a/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
+++ b/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
@@ -57,6 +57,12 @@
   return nil;
 }
 
+/**
+ * Returns the formatted MccMnc if the inputs are valid, otherwise nil
+ * @param mcc The Mobile Country Code returned from `getNetworkMobileCountryCode`
+ * @param mnc The Mobile Network Code returned from `getNetworkMobileNetworkCode`
+ * @returns A string with the concatenated mccMnc if both inputs are valid, otherwise nil
+ */
 + (NSString *_Nullable)formatMcc:(NSString *)mcc andMNC:(NSString *)mnc {
   // These are both nil if the target does not support mobile connectivity
   if (mcc == nil && mnc == nil) {

--- a/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
+++ b/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
@@ -85,11 +85,16 @@
 + (GULNetworkType)getNetworkType {
   GULNetworkType networkType = GULNetworkTypeNone;
 
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
   static SCNetworkReachabilityRef reachabilityRef = 0;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     reachabilityRef = SCNetworkReachabilityCreateWithName(kCFAllocatorSystemDefault, "google.com");
   });
+
+  if (!reachabilityRef) {
+    return GULNetworkTypeNone;
+  }
 
   SCNetworkReachabilityFlags reachabilityFlags = 0;
   SCNetworkReachabilityGetFlags(reachabilityRef, &reachabilityFlags);
@@ -102,13 +107,18 @@
       networkType = GULNetworkTypeWIFI;
     }
   }
+#endif
 
   return networkType;
 }
 
 + (NSString *)getNetworkRadioType {
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
   CTTelephonyNetworkInfo *networkInfo = [GULNetworkInfo getNetworkInfo];
   return networkInfo.currentRadioAccessTechnology;
+#else
+  return @"";
+#endif
 }
 
 @end

--- a/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
+++ b/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
@@ -1,18 +1,16 @@
-/*
- * Copyright 2022 Google
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #import "GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h"
 

--- a/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
+++ b/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h"
+
+#import <Foundation/Foundation.h>
+
+#import <SystemConfiguration/SystemConfiguration.h>
+
+#import <TargetConditionals.h>
+#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h") && !TARGET_OS_MACCATALYST && \
+                  !TARGET_OS_OSX && !TARGET_OS_TV
+#define TARGET_HAS_MOBILE_CONNECTIVITY
+#import <CoreTelephony/CTCarrier.h>
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#endif
+
+@implementation GULNetworkInfo
+
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
++ (CTTelephonyNetworkInfo *)getNetworkInfo {
+  static CTTelephonyNetworkInfo *networkInfo;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    networkInfo = [[CTTelephonyNetworkInfo alloc] init];
+  });
+  return networkInfo;
+}
+#endif
+
++ (NSString *_Nullable)getNetworkMobileCountryCode {
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+  CTTelephonyNetworkInfo *networkInfo = [GULNetworkInfo getNetworkInfo];
+  CTCarrier *provider = networkInfo.subscriberCellularProvider;
+  return provider.mobileCountryCode;
+#endif
+  return nil;
+}
+
++ (NSString *_Nullable)getNetworkMobileNetworkCode {
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+  CTTelephonyNetworkInfo *networkInfo = [GULNetworkInfo getNetworkInfo];
+  CTCarrier *provider = networkInfo.subscriberCellularProvider;
+  return provider.mobileNetworkCode;
+#endif
+  return nil;
+}
+
++ (NSString *_Nullable)formatMcc:(NSString *)mcc andMNC:(NSString *)mnc {
+  // These are both nil if the target does not support mobile connectivity
+  if (mcc == nil && mnc == nil) {
+    return nil;
+  }
+
+  if (mcc.length != 3 || mnc.length < 2 || mnc.length > 3) {
+    return nil;
+  }
+
+  // If the resulting appended mcc + mnc contains characters that are not
+  // decimal digits, return nil
+  static NSCharacterSet *notDigits;
+  static dispatch_once_t token;
+  dispatch_once(&token, ^{
+    notDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+  });
+  NSString *mccMnc = [mcc stringByAppendingString:mnc];
+  if ([mccMnc rangeOfCharacterFromSet:notDigits].location != NSNotFound) {
+    return nil;
+  }
+
+  return mccMnc;
+}
+
++ (GULNetworkType)getNetworkType {
+  GULNetworkType networkType = GULNetworkTypeNone;
+
+  static SCNetworkReachabilityRef reachabilityRef = 0;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    reachabilityRef = SCNetworkReachabilityCreateWithName(kCFAllocatorSystemDefault, "google.com");
+  });
+
+  SCNetworkReachabilityFlags reachabilityFlags = 0;
+  SCNetworkReachabilityGetFlags(reachabilityRef, &reachabilityFlags);
+
+  // Parse the network flags to set the network type.
+  if (reachabilityFlags & kSCNetworkReachabilityFlagsReachable) {
+    if (reachabilityFlags & kSCNetworkReachabilityFlagsIsWWAN) {
+      networkType = GULNetworkTypeMobile;
+    } else {
+      networkType = GULNetworkTypeWIFI;
+    }
+  }
+
+  return networkType;
+}
+
++ (NSString *)getNetworkRadioType {
+  CTTelephonyNetworkInfo *networkInfo = [GULNetworkInfo getNetworkInfo];
+  return networkInfo.currentRadioAccessTechnology;
+}
+
+@end

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, GULNetworkType) {
 /// Collection of utilities to read network status information
 @interface GULNetworkInfo : NSObject
 
-/// Returns the cellular mobile country code (mnc) if CoreTelephony is supported, otherwise nil
+/// Returns the cellular mobile country code (mcc) if CoreTelephony is supported, otherwise nil
 + (NSString *_Nullable)getNetworkMobileCountryCode;
 
 /// Returns the cellular mobile network code (mnc) if CoreTelephony is supported, otherwise nil
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSInteger, GULNetworkType) {
 /**
  * Returns the formatted MccMnc if the inputs are valid, otherwise nil
  * @param mcc The Mobile Country Code returned from `getNetworkMobileCountryCode`
- * @param mnc The Mobile Networkf Code returned from `getNetworkMobileNetworkCode`
+ * @param mnc The Mobile Network Code returned from `getNetworkMobileNetworkCode`
  * @returns A string with the concatenated mccMnc if both inputs are valid, otherwise nil
  */
 + (NSString *_Nullable)formatMcc:(NSString *_Nullable)mcc andMNC:(NSString *_Nullable)mnc;

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The type of network that the device is running with. Values should correspond to the NetworkType
+/// values in android/play/playlog/proto/clientanalytics.proto
+typedef NS_ENUM(NSInteger, GULNetworkType) {
+  GULNetworkTypeNone = -1,
+  GULNetworkTypeMobile = 0,
+  GULNetworkTypeWIFI = 1,
+};
+
+/// Collection of utilities to read network status information
+@interface GULNetworkInfo : NSObject
+
+/// Returns the cellular mobile country code (mnc) if CoreTelephony is supported, otherwise nil
++ (NSString *_Nullable)getNetworkMobileCountryCode;
+
+/// Returns the cellular mobile network code (mnc) if CoreTelephony is supported, otherwise nil
++ (NSString *_Nullable)getNetworkMobileNetworkCode;
+
+/**
+ * Returns the formatted MccMnc if the inputs are valid, otherwise nil
+ * @param mcc The Mobile Country Code returned from `getNetworkMobileCountryCode`
+ * @param mnc The Mobile Networkf Code returned from `getNetworkMobileNetworkCode`
+ * @returns A string with the concatenated mccMnc if both inputs are valid, otherwise nil
+ */
++ (NSString *_Nullable)formatMcc:(NSString *_Nullable)mcc andMNC:(NSString *_Nullable)mnc;
+
+/// Returns an enum indicating the network type. The enum values should be easily transferrable to
+/// the NetworkType value in android/play/playlog/proto/clientanalytics.proto
++ (GULNetworkType)getNetworkType;
+
+/// Returns a string indicating the radio access technology used by the app. The return value will
+/// be one of CTRadioAccess constants defined in
+/// https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/radio_access_technology_constants
++ (NSString *)getNetworkRadioType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
@@ -1,18 +1,16 @@
-/*
- * Copyright 2022 Google
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #import <Foundation/Foundation.h>
 

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULNetworkInfo.h
@@ -42,7 +42,9 @@ typedef NS_ENUM(NSInteger, GULNetworkType) {
 + (NSString *_Nullable)formatMcc:(NSString *_Nullable)mcc andMNC:(NSString *_Nullable)mnc;
 
 /// Returns an enum indicating the network type. The enum values should be easily transferrable to
-/// the NetworkType value in android/play/playlog/proto/clientanalytics.proto
+/// the NetworkType value in android/play/playlog/proto/clientanalytics.proto. Right now this always
+/// returns None on platforms other than iOS. This should be updated in the future to return Wi-Fi
+/// values for the other platforms when applicable.
 + (GULNetworkType)getNetworkType;
 
 /// Returns a string indicating the radio access technology used by the app. The return value will

--- a/GoogleUtilities/Tests/SwiftUnit/GULNetworkInfoTests.swift
+++ b/GoogleUtilities/Tests/SwiftUnit/GULNetworkInfoTests.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import GoogleUtilities
+
+class GULNetworkInfoTests: XCTestCase {
+
+  func test_mccMNC_validatesCorrectly() {
+    let expectations: [(mobileCountryCode: String, mobileNetworkCode: String, expected: String)] = [
+      ("310", "004", "310004"),
+      ("310", "01", "31001"),
+      ("001", "50", "00150"),
+    ]
+
+    expectations
+      .forEach { (mobileCountryCode: String, mobileNetworkCode: String, expected: String) in
+        let format = GULNetworkInfo.formatMcc(mobileCountryCode, andMNC: mobileNetworkCode)
+        XCTAssertEqual(format, expected)
+      }
+  }
+
+  func test_mccMNC_isEmptyWhenInvalid() {
+    let expectations: [(mobileCountryCode: String?, mobileNetworkCode: String?)] = [
+      ("3100", "004"), // MCC too long
+      ("31", "01"), // MCC too short
+      ("310", "0512"), // MNC too long
+      ("L00", "003"), // MCC contains non-decimal characters
+      ("300", "00T"), // MNC contains non-decimal characters
+      (nil, nil), // Handle nils gracefully
+      (nil, "001"),
+      ("310", nil),
+    ]
+
+    expectations.forEach { (mobileCountryCode: String?, mobileNetworkCode: String?) in
+      let format = GULNetworkInfo.formatMcc(mobileCountryCode, andMNC: mobileNetworkCode)
+      XCTAssertEqual(format, nil)
+    }
+  }
+}

--- a/GoogleUtilities/Tests/SwiftUnit/GULNetworkInfoTests.swift
+++ b/GoogleUtilities/Tests/SwiftUnit/GULNetworkInfoTests.swift
@@ -18,7 +18,6 @@ import XCTest
 @testable import GoogleUtilities
 
 class GULNetworkInfoTests: XCTestCase {
-
   func test_mccMNC_validatesCorrectly() {
     let expectations: [(mobileCountryCode: String, mobileNetworkCode: String, expected: String)] = [
       ("310", "004", "310004"),


### PR DESCRIPTION
Similar to https://github.com/google/GoogleUtilities/pull/90 and https://github.com/google/GoogleUtilities/pull/89, the main purpose of this PR is to share that code with the new FirebaseSessions SDK for the purposes of filtering events consistently between the 2 products.

These functions are utilities for FirebasePerformance to include along with traces for added context to performance issues.

I wasn't totally sure where to put them.
 - I put them in GoogleUtilities/Environment because it seemed thematically similar to like determining what's going on with the app in its environment
 - They didn't seem to belong in GoogleUtilities/Reachability, but there might be an argument for that
 - AppEnvironmentUtil felt overloaded with these added
 - GoogleUtilities/Network were mainly for url connections