### PR TITLE
Fix build warning by deleting unsupported old OS code

### DIFF
--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -478,38 +478,8 @@
 }
 
 /// Creates a background session configuration with the session ID using the supported method.
-- (NSURLSessionConfiguration *)backgroundSessionConfigWithSessionID:(NSString *)sessionID
-    API_AVAILABLE(ios(7.0)) {
-#if (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&         \
-     MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10) || \
-    TARGET_OS_TV ||                                              \
-    (TARGET_OS_IOS && defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0)
-
-  // iOS 8/10.10 builds require the new backgroundSessionConfiguration method name.
+- (NSURLSessionConfiguration *)backgroundSessionConfigWithSessionID:(NSString *)sessionID {
   return [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionID];
-
-#elif (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&        \
-       MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10) || \
-    (TARGET_OS_IOS && defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0)
-
-  // Do a runtime check to avoid a deprecation warning about using
-  // +backgroundSessionConfiguration: on iOS 8.
-  if ([NSURLSessionConfiguration
-          respondsToSelector:@selector(backgroundSessionConfigurationWithIdentifier:)]) {
-    // Running on iOS 8+/OS X 10.10+.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-    return [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionID];
-#pragma clang diagnostic pop
-  } else {
-    // Running on iOS 7/OS X 10.9.
-    return [NSURLSessionConfiguration backgroundSessionConfiguration:sessionID];
-  }
-
-#else
-  // Building with an SDK earlier than iOS 8/OS X 10.10.
-  return [NSURLSessionConfiguration backgroundSessionConfiguration:sessionID];
-#endif
 }
 
 - (void)maybeRemoveTempFilesAtURL:(NSURL *)folderURL expiringTime:(NSTimeInterval)staleTime {


### PR DESCRIPTION
Fix this warning:

    - WARN  | [GoogleUtilities/Network,GoogleUtilities/AppDelegateSwizzler] xcodebuild:  /Users/paulbeusterien/github/GoogleUtilities/GoogleUtilities/Network/GULNetworkURLSession.m:511:37: warning: 'backgroundSessionConfiguration:' is deprecated: first deprecated in watchOS 2.0 [-Wdeprecated-declarations]