### PR TITLE
[Environment] Calling `+[GULAppEnvironmentUtil applePlatform]` returns visionOS specific value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.11.3 (SwiftPM Only)
+- Calling `+[GULAppEnvironmentUtil applePlatform]` now returns 'visionos' when
+  running on visionOS.
+
 # 7.11.2 (SwiftPM Only)
 - Fix build errors on the visionOS platform. (#108)
 

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
@@ -53,7 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return YES if Swift runtime detected in the app.
 + (BOOL)hasSwiftRuntime __deprecated;
 
-/// @return An Apple platform. Possible values "ios", "tvos", "macos", "watchos", "maccatalyst".
+/// @return An Apple platform. Possible values "ios", "tvos", "macos", "watchos", "maccatalyst", and
+/// "visionos".
 + (NSString *)applePlatform;
 
 /// @return An Apple Device platform. Same possible values as `applePlatform`, with the addition of

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -334,7 +334,7 @@ static BOOL HasEmbeddedMobileProvision(void) {
   // `true`, which means the condition list is order-sensitive.
 #if TARGET_OS_MACCATALYST
   applePlatform = @"maccatalyst";
-#elif TARGET_OS_IOS
+#elif TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 #if defined(__IPHONE_14_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
   if (@available(iOS 14.0, *)) {
     // Early iOS 14 betas do not include isiOSAppOnMac (#6969)
@@ -353,6 +353,8 @@ static BOOL HasEmbeddedMobileProvision(void) {
   applePlatform = @"macos";
 #elif TARGET_OS_WATCH
   applePlatform = @"watchos";
+#elif defined(TARGET_OS_XR) && TARGET_OS_XR
+  applePlatform = @"visionos";
 #endif // TARGET_OS_MACCATALYST
 
   return applePlatform;

--- a/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
@@ -84,7 +84,7 @@
   // `true`.
 #if TARGET_OS_MACCATALYST
   NSString *expectedPlatform = @"maccatalyst";
-#elif TARGET_OS_IOS
+#elif TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   NSString *expectedPlatform = @"ios";
 #endif  // TARGET_OS_MACCATALYST
 
@@ -100,6 +100,10 @@
   NSString *expectedPlatform = @"watchos";
 #endif  // TARGET_OS_WATCH
 
+#if defined(TARGET_OS_XR) && TARGET_OS_XR
+  NSString *expectedPlatform = @"visionos";
+#endif  // defined(TARGET_OS_XR) && TARGET_OS_XR
+
   XCTAssertEqualObjects([GULAppEnvironmentUtil applePlatform], expectedPlatform);
 }
 
@@ -108,7 +112,7 @@
   // `true`.
 #if TARGET_OS_MACCATALYST
   NSString *expectedPlatform = @"maccatalyst";
-#elif TARGET_OS_IOS
+#elif TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   NSString *expectedPlatform = @"ios";
 
   if ([[UIDevice currentDevice].model.lowercaseString containsString:@"ipad"] ||
@@ -128,6 +132,10 @@
 #if TARGET_OS_WATCH
   NSString *expectedPlatform = @"watchos";
 #endif  // TARGET_OS_WATCH
+
+#if defined(TARGET_OS_XR) && TARGET_OS_XR
+  NSString *expectedPlatform = @"visionos";
+#endif  // defined(TARGET_OS_XR) && TARGET_OS_XR
 
   XCTAssertEqualObjects([GULAppEnvironmentUtil appleDevicePlatform], expectedPlatform);
 }


### PR DESCRIPTION
Upon merging, I will do an internal copybara to smoke test and then publish a SwiftPM-only patch release. This change is backwards compatible, as proven by CI.