### PR TITLE
[Network] Resolve Xcode 15 Beta 4 runtime warning

### DIFF
--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -158,6 +158,12 @@
                                             delegate:self
                                        delegateQueue:[NSOperationQueue mainQueue]];
     postRequestTask = [session uploadTaskWithRequest:request fromData:request.HTTPBody];
+
+    // Xcode 15 Beta 4: A URLRequest should not have a non-nil `HTTPBody`.
+    NSData *data = [request.HTTPBody copy];
+    NSMutableURLRequest *compliantRequest = [request mutableCopy];
+    compliantRequest.HTTPBody = nil;
+    postRequestTask = [session uploadTaskWithRequest:compliantRequest.copy fromData:data];
   }
 
   if (!session || !postRequestTask) {

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -164,7 +164,7 @@
     NSMutableURLRequest *requestWithoutHTTPBody = [request mutableCopy];
     requestWithoutHTTPBody.HTTPBody = nil;
 
-    postRequestTask = [session uploadTaskWithRequest:requestWithoutHTTPBody.copy
+    postRequestTask = [session uploadTaskWithRequest:requestWithoutHTTPBody
                                             fromData:givenRequestHTTPBody];
   }
 

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -157,13 +157,15 @@
     session = [NSURLSession sessionWithConfiguration:_sessionConfig
                                             delegate:self
                                        delegateQueue:[NSOperationQueue mainQueue]];
-    postRequestTask = [session uploadTaskWithRequest:request fromData:request.HTTPBody];
+    // To avoid a runtime warning in Xcode 15 Beta 4, the given `URLRequest`
+    // should have a nil `HTTPBody`. To workaround this, the given `URLRequest`
+    // is copied and the `HTTPBody` data is removed.
+    NSData *givenRequestHTTPBody = [request.HTTPBody copy];
+    NSMutableURLRequest *requestWithoutHTTPBody = [request mutableCopy];
+    requestWithoutHTTPBody.HTTPBody = nil;
 
-    // Xcode 15 Beta 4: A URLRequest should not have a non-nil `HTTPBody`.
-    NSData *data = [request.HTTPBody copy];
-    NSMutableURLRequest *compliantRequest = [request mutableCopy];
-    compliantRequest.HTTPBody = nil;
-    postRequestTask = [session uploadTaskWithRequest:compliantRequest.copy fromData:data];
+    postRequestTask = [session uploadTaskWithRequest:requestWithoutHTTPBody.copy
+                                            fromData:givenRequestHTTPBody];
   }
 
   if (!session || !postRequestTask) {


### PR DESCRIPTION
### Context
See https://github.com/firebase/firebase-ios-sdk/issues/11536 for details. Xcode 15 Beta 3 introduces a runtime warning when creating an upload task from a URL request that _contains_  a non-nil HTTPBody field. I can't find any reasoning as to why this is now a warnings, but it looks like URL request objects should only contain metadata about the request, not the data itself.

Fix https://github.com/firebase/firebase-ios-sdk/issues/11536

After merging, will open a new PR with a changelog update and podspec bump. We can do a CocoaPods + SPM release for this. This will align the two, since we have done some SPM-only releases in the time since the last CocoaPods release. 

cc: @htcgh, @pcfba