### PR TITLE
[Infra] Fix flaky 'NSURLSession+GULPromises' test

### DIFF
--- a/GoogleUtilities/Tests/Unit/Environment/NSURLSession+GULPromisesTests.m
+++ b/GoogleUtilities/Tests/Unit/Environment/NSURLSession+GULPromisesTests.m
@@ -63,7 +63,7 @@
 
   __auto_type taskPromise = [self.URLSessionMock gul_dataTaskPromiseWithRequest:request];
 
-  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+  XCTAssert(FBLWaitForPromisesWithTimeout(1.0));
 
   XCTAssertTrue(taskPromise.isFulfilled);
   XCTAssertNil(taskPromise.error);


### PR DESCRIPTION
A couple observations while trying to reproduce.
- The test fails in what appears to be random fashion. When it fails, it's due to an uncaught exception. I'm not sure where it's coming from but I suspect it may be OCMock related... not sure
- It _seems_ like disabling xcpretty in the invocation increases the chance of it crashing
- It is not reproducible in Xcode
- invocation: `../firebase-ios-sdk/scripts/test_catalyst.sh GoogleUtilities test GoogleUtilities-Unit-unit`


CI is green though I'm not super convinced this will work. See #120 for alt. approach that does some code cleanup.
