### PR TITLE
Changing podspec file's license from Apache to Apache-2.0

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -9,7 +9,7 @@ other Google CocoaPods. They're not intended for direct public usage.
                        DESC
 
   s.homepage         = 'https://github.com/google/GoogleUtilities'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {


### PR DESCRIPTION
This is to address an issue similar to https://github.com/firebase/firebase-ios-sdk/issues/9781. 
The pod has `Apache-2.0` license mentioned in the [LICENSE](https://github.com/google/GoogleUtilities/blob/main/LICENSE).
But, the podspec file sets :license :type as `Apache`
This correction ensures alignment with the correct license, making it consistent and accurate.

