### PR TITLE
[Infra] Remove more non-license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -203,9 +203,6 @@
 
 ================================================================================
 
-The following copyright from Landon J. Fuller applies to the isAppEncrypted
-function in Environment/third_party/GULAppEnvironmentUtil.m.
-
 Copyright (c) 2017 Landon J. Fuller <landon@landonf.org>
 All rights reserved.
 


### PR DESCRIPTION
This text gets flagged by internal checks for being "unidentified". I think it's safe to remove. It is also outdated as we've changed the referenced file path.