### PR TITLE
Fix: missing vision os simulator model case

### DIFF
--- a/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
@@ -167,6 +167,8 @@ static BOOL HasEmbeddedMobileProvision(void) {
     model = @"watchOS Simulator";
 #elif TARGET_OS_TV
     model = @"tvOS Simulator";
+#elif TARGET_OS_VISION
+    model = @"visionOS Simulator";
 #elif TARGET_OS_IPHONE
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
       case UIUserInterfaceIdiomPhone:


### PR DESCRIPTION
## WHY

- Environment: Xcode 15.1 Beta

<img width="1167" alt="スクリーンショット 2023-10-04 15 18 14" src="https://github.com/google/GoogleUtilities/assets/15936908/98d8cdc0-c500-4c3b-8d27-80293a3f8063">

- GULAppEnvironmentUtil.m defines `TARGET_OS_VISION` preprocessor macro.
- However I found a missing case and still can't build the GULEnvironment target in visionOS.

## WHAT

- Add vision os simulator model case.