### PR TITLE
Fix visionOS build in Xcode 15.1 beta 1

### DIFF
--- a/GoogleUtilities/AppDelegateSwizzler/Public/GoogleUtilities/GULApplication.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Public/GoogleUtilities/GULApplication.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <UIKit/UIKit.h>
 

--- a/GoogleUtilities/AppDelegateSwizzler/Public/GoogleUtilities/GULApplication.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Public/GoogleUtilities/GULApplication.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 
 #import <UIKit/UIKit.h>
 

--- a/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
@@ -21,7 +21,7 @@
 
 #import "third_party/IsAppEncrypted/Public/IsAppEncrypted.h"
 
-#if TARGET_OS_IOS || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
 #endif
 
@@ -167,7 +167,9 @@ static BOOL HasEmbeddedMobileProvision(void) {
     model = @"watchOS Simulator";
 #elif TARGET_OS_TV
     model = @"tvOS Simulator";
-#elif TARGET_OS_IPHONE
+#elif defined(TARGET_OS_VISION) && TARGET_OS_VISION
+    model = @"visionOS Simulator";
+#elif TARGET_OS_IOS
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
       case UIUserInterfaceIdiomPhone:
         model = @"iOS Simulator (iPhone)";
@@ -191,9 +193,10 @@ static BOOL HasEmbeddedMobileProvision(void) {
 }
 
 + (NSString *)systemVersion {
-#if TARGET_OS_IOS || TARGET_OS_VISION
+#if TARGET_OS_IOS
   return [UIDevice currentDevice].systemVersion;
-#elif TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
+#elif TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH || \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
   // Assemble the systemVersion, excluding the patch version if it's 0.
   NSOperatingSystemVersion osVersion = [NSProcessInfo processInfo].operatingSystemVersion;
   NSMutableString *versionString = [[NSMutableString alloc]

--- a/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
@@ -21,7 +21,7 @@
 
 #import "third_party/IsAppEncrypted/Public/IsAppEncrypted.h"
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_VISION
 #import <UIKit/UIKit.h>
 #endif
 
@@ -191,7 +191,7 @@ static BOOL HasEmbeddedMobileProvision(void) {
 }
 
 + (NSString *)systemVersion {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_VISION
   return [UIDevice currentDevice].systemVersion;
 #elif TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
   // Assemble the systemVersion, excluding the patch version if it's 0.

--- a/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
@@ -21,7 +21,7 @@
 
 #import "third_party/IsAppEncrypted/Public/IsAppEncrypted.h"
 
-#if TARGET_OS_IOS || TARGET_OS_VISION
+#if TARGET_OS_IOS || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #import <UIKit/UIKit.h>
 #endif
 


### PR DESCRIPTION
In Xcode 15.1 `TARGET_OS_IOS` is now `0` instead of `1`. This PR fixes the build on visionOS (and resolves #130) but does not address all issues in tests.

In follow-ups we should audit uses of `TARGET_OS_IOS` throughout the codebase.