### PR TITLE
[visionOS] Fix `GULReachabilityCheckerTest` in Xcode 15.1 beta 1

### DIFF
--- a/GoogleUtilities/Reachability/GULReachabilityChecker.m
+++ b/GoogleUtilities/Reachability/GULReachabilityChecker.m
@@ -180,7 +180,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
     // Reachable flag is set. Check further flags.
     if (!(flags & kSCNetworkReachabilityFlagsConnectionRequired)) {
 // Connection required flag is not set, so we have connectivity.
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
       status = (flags & kSCNetworkReachabilityFlagsIsWWAN) ? kGULReachabilityViaCellular
                                                            : kGULReachabilityViaWifi;
 #elif TARGET_OS_OSX
@@ -191,7 +191,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
                !(flags & kSCNetworkReachabilityFlagsInterventionRequired)) {
 // If the connection on demand or connection on traffic flag is set, and user intervention
 // is not required, we have connectivity.
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
       status = (flags & kSCNetworkReachabilityFlagsIsWWAN) ? kGULReachabilityViaCellular
                                                            : kGULReachabilityViaWifi;
 #elif TARGET_OS_OSX


### PR DESCRIPTION
In Xcode 15.1 `TARGET_OS_IOS` is now `0` instead of `1`. This PR fixes [GULReachabilityCheckerTest](https://github.com/google/GoogleUtilities/blob/4780d5c011278da93839a4cef27d3cec9efa3938/GoogleUtilities/Tests/Unit/Reachability/GULReachabilityCheckerTest.m) when running on the Apple Vision Pro simulator.