### PR TITLE
Update CocoaPods to v1.14.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.14.0'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'
-# activesupport is locked because of https://github.com/CocoaPods/CocoaPods/issues/12081
-gem 'activesupport', '7.0.8'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
 
-gem 'cocoapods', '1.13.0'
+gem 'cocoapods', '1.14.0'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'
 # activesupport is locked because of https://github.com/CocoaPods/CocoaPods/issues/12081

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (= 7.0.8)
   cocoapods (= 1.14.0)
   cocoapods-generate (= 2.0.1)
   danger (= 8.4.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,12 +19,12 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.13.0)
+    cocoapods (1.14.0)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.13.0)
+      cocoapods-core (= 1.14.0)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.6.0, < 2.0)
+      cocoapods-downloader (>= 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.6.0, < 2.0)
@@ -37,7 +37,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.13.0)
+    cocoapods-core (1.14.0)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -49,7 +49,7 @@ GEM
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
     cocoapods-disable-podfile-validations (0.1.1)
-    cocoapods-downloader (1.6.3)
+    cocoapods-downloader (2.0)
     cocoapods-generate (2.0.1)
       cocoapods-disable-podfile-validations (~> 0.1.1)
     cocoapods-plugins (1.0.0)
@@ -158,7 +158,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (= 7.0.8)
-  cocoapods (= 1.13.0)
+  cocoapods (= 1.14.0)
   cocoapods-generate (= 2.0.1)
   danger (= 8.4.5)
 


### PR DESCRIPTION
Updated to CocoaPods 1.14.0 to match https://github.com/firebase/firebase-ios-sdk/pull/12008.