### PR TITLE
Use guaranteed const for associated object key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   `GULHeartbeatDateStorageUserDefaults` APIs. (#164)
 - Remove '+ [GULAppEnvironmentUtil isIOS7OrHigher]' API. (#165)
 - Remove '+ [GULAppEnvironmentUtil hasSwiftRuntime]' API. (#166)
+- Fix an issue where ObjC associated objects were sometimes set with a
+  non-const key, potentially resulting in undefined behavior. (#141)
 
 # 7.13.3
 - Rename parameter placeholder in `GULSecureCoding` unarchiving API to avoid

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler+Internal.h
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler+Internal.h
@@ -14,7 +14,7 @@
 
 #import "GoogleUtilities/ISASwizzler/Public/GoogleUtilities/GULObjectSwizzler.h"
 
-FOUNDATION_EXPORT NSString *kGULSwizzlerAssociatedObjectKey;
+FOUNDATION_EXPORT const NSString *const kGULSwizzlerAssociatedObjectKey;
 
 @interface GULObjectSwizzler (Internal)
 

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -33,7 +33,7 @@
 #pragma mark - Class methods
 
 + (void)setAssociatedObject:(id)object
-                        key:(NSString *)key
+                        key:(const void *)key
                       value:(nullable id)value
                 association:(GUL_ASSOCIATION)association {
   objc_AssociationPolicy resolvedAssociation;
@@ -61,11 +61,11 @@
     default:
       break;
   }
-  objc_setAssociatedObject(object, key.UTF8String, value, resolvedAssociation);
+  objc_setAssociatedObject(object, key, value, resolvedAssociation);
 }
 
-+ (nullable id)getAssociatedObject:(id)object key:(NSString *)key {
-  return objc_getAssociatedObject(object, key.UTF8String);
++ (nullable id)getAssociatedObject:(id)object key:(const void *)key {
+  return objc_getAssociatedObject(object, key);
 }
 
 #pragma mark - Instance methods
@@ -81,7 +81,7 @@
   }
 
   GULObjectSwizzler *existingSwizzler =
-      [[self class] getAssociatedObject:object key:kGULSwizzlerAssociatedObjectKey];
+      [[self class] getAssociatedObject:object key:&kGULSwizzlerAssociatedObjectKey];
   if ([existingSwizzler isKindOfClass:[GULObjectSwizzler class]]) {
     // The object has been swizzled already, no need to swizzle again.
     return existingSwizzler;
@@ -110,7 +110,7 @@
   class_replaceMethod(targetClass, selector, implementation, typeEncoding);
 }
 
-- (void)setAssociatedObjectWithKey:(NSString *)key
+- (void)setAssociatedObjectWithKey:(const void *)key
                              value:(id)value
                        association:(GUL_ASSOCIATION)association {
   __strong id swizzledObject = _swizzledObject;
@@ -119,7 +119,7 @@
   }
 }
 
-- (nullable id)getAssociatedObjectForKey:(NSString *)key {
+- (nullable id)getAssociatedObjectForKey:(const void *)key {
   __strong id swizzledObject = _swizzledObject;
   if (swizzledObject) {
     return [[self class] getAssociatedObject:swizzledObject key:key];
@@ -129,9 +129,8 @@
 
 - (void)swizzle {
   __strong id swizzledObject = _swizzledObject;
-
   GULObjectSwizzler *existingSwizzler =
-      [[self class] getAssociatedObject:swizzledObject key:kGULSwizzlerAssociatedObjectKey];
+      [[self class] getAssociatedObject:swizzledObject key:&kGULSwizzlerAssociatedObjectKey];
   if (existingSwizzler != nil) {
     NSAssert(existingSwizzler == self, @"The swizzled object has a different swizzler.");
     // The object has been swizzled already.
@@ -140,7 +139,7 @@
 
   if (swizzledObject) {
     [GULObjectSwizzler setAssociatedObject:swizzledObject
-                                       key:kGULSwizzlerAssociatedObjectKey
+                                       key:&kGULSwizzlerAssociatedObjectKey
                                      value:self
                                association:GUL_ASSOCIATION_RETAIN];
 

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -17,7 +17,7 @@
 #import "GoogleUtilities/ISASwizzler/GULObjectSwizzler+Internal.h"
 #import "GoogleUtilities/ISASwizzler/Public/GoogleUtilities/GULSwizzledObject.h"
 
-NSString *kGULSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
+const NSString *const kGULSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
 
 @interface GULSwizzledObject ()
 
@@ -46,7 +46,7 @@ NSString *kGULSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
 }
 
 - (GULObjectSwizzler *)gul_objectSwizzler {
-  return [GULObjectSwizzler getAssociatedObject:self key:kGULSwizzlerAssociatedObjectKey];
+  return [GULObjectSwizzler getAssociatedObject:self key:&kGULSwizzlerAssociatedObjectKey];
 }
 
 #pragma mark - Donor methods

--- a/GoogleUtilities/ISASwizzler/Public/GoogleUtilities/GULObjectSwizzler.h
+++ b/GoogleUtilities/ISASwizzler/Public/GoogleUtilities/GULObjectSwizzler.h
@@ -55,7 +55,7 @@ typedef OBJC_ENUM(uintptr_t, GUL_ASSOCIATION){
  *  @param association The mechanism to use when associating the objects.
  */
 + (void)setAssociatedObject:(id)object
-                        key:(NSString *)key
+                        key:(const void *)key
                       value:(nullable id)value
                 association:(GUL_ASSOCIATION)association;
 
@@ -65,7 +65,7 @@ typedef OBJC_ENUM(uintptr_t, GUL_ASSOCIATION){
  *  @param object The object that will be queried for the associated object.
  *  @param key The key of the associated object.
  */
-+ (nullable id)getAssociatedObject:(id)object key:(NSString *)key;
++ (nullable id)getAssociatedObject:(id)object key:(const void *)key;
 
 /** Please use the designated initializer. */
 - (instancetype)init NS_UNAVAILABLE;
@@ -88,7 +88,7 @@ typedef OBJC_ENUM(uintptr_t, GUL_ASSOCIATION){
  *  @param value The value to associate to the swizzled object.
  *  @param association The mechanism to use when associating the objects.
  */
-- (void)setAssociatedObjectWithKey:(NSString *)key
+- (void)setAssociatedObjectWithKey:(const void *)key
                              value:(id)value
                        association:(GUL_ASSOCIATION)association;
 
@@ -97,7 +97,7 @@ typedef OBJC_ENUM(uintptr_t, GUL_ASSOCIATION){
  *
  *  @param key The key of the associated object.
  */
-- (nullable id)getAssociatedObjectForKey:(NSString *)key;
+- (nullable id)getAssociatedObjectForKey:(const void *)key;
 
 /** Copies a selector from an existing class onto the generated dynamic subclass
  *  that this object will adopt. This mechanism can be used to add methods to

--- a/GoogleUtilities/Tests/Unit/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Tests/Unit/Swizzler/GULObjectSwizzlerTest.m
@@ -353,7 +353,7 @@
 
     // Release GULObjectSwizzler
     [GULObjectSwizzler setAssociatedObject:proxyObject
-                                       key:kGULSwizzlerAssociatedObjectKey
+                                       key:&kGULSwizzlerAssociatedObjectKey
                                      value:nil
                                association:GUL_ASSOCIATION_RETAIN];
   }
@@ -395,7 +395,7 @@
 
     // Release GULObjectSwizzler
     [GULObjectSwizzler setAssociatedObject:object
-                                       key:kGULSwizzlerAssociatedObjectKey
+                                       key:&kGULSwizzlerAssociatedObjectKey
                                      value:nil
                                association:GUL_ASSOCIATION_RETAIN];
 
@@ -439,7 +439,7 @@
 
     // Release GULObjectSwizzler
     [GULObjectSwizzler setAssociatedObject:object
-                                       key:kGULSwizzlerAssociatedObjectKey
+                                       key:&kGULSwizzlerAssociatedObjectKey
                                      value:nil
                                association:GUL_ASSOCIATION_RETAIN];
 


### PR DESCRIPTION
From the [Foundation docs for `-[NSString UTF8String]`](https://developer.apple.com/documentation/foundation/nsstring/1411189-utf8string?language=objc):

>This C string is a pointer to a structure inside the string object, which may have a lifetime shorter than the string object and will certainly not have a longer lifetime. Therefore, you should copy the C string if it needs to be stored outside of the memory context in which you use this property.

Since the inner pointer may have a shorter lifespan than the owning NSString, it shouldn't be used as a constant value. This PR replaces it with the address of the variable, which is guaranteed to be constant during the lifetime of the string constant.