### PR TITLE
[SwiftPM] Fix target with invalid name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fix improperly formatted target name that blocks App Store submission. (#140)
+
 # 7.12.0
 - Added a logging level getter, `GULGetLoggerLevel`. (#138)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 7.12.1 (SwiftPM Only)
 - Fix improperly formatted target name that blocks App Store submission. (#140)
 
 # 7.12.0

--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,7 @@ let package = Package(
       name: "GoogleUtilities-Environment",
       dependencies: [
         .product(name: "FBLPromises", package: "Promises"),
-        .target(name: "third_party-IsAppEncrypted"),
+        .target(name: "third-party-IsAppEncrypted"),
       ],
       path: "GoogleUtilities/Environment",
       publicHeadersPath: "Public",
@@ -114,7 +114,7 @@ let package = Package(
     ),
 
     .target(
-      name: "third_party-IsAppEncrypted",
+      name: "third-party-IsAppEncrypted",
       path: "third_party/IsAppEncrypted",
       exclude: ["LICENSE"],
       publicHeadersPath: "Public",


### PR DESCRIPTION
Underscore in target name should instead be a dash.

Fixes #140 