### PR TITLE
[Infra] Refactor privacy manifests to address #150

### DIFF
--- a/GoogleUtilities/AppDelegateSwizzler/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/AppDelegateSwizzler/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/AppDelegateSwizzler/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/AppDelegateSwizzler/Resources/PrivacyInfo.xcprivacy
@@ -12,23 +12,6 @@
         </array>
         <key>NSPrivacyAccessedAPITypes</key>
         <array>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>1C8F.1</string>
-                                <string>C56D.1</string>
-                        </array>
-                </dict>
         </array>
 </dict>
 </plist>

--- a/GoogleUtilities/Environment/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Environment/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/Environment/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Environment/Resources/PrivacyInfo.xcprivacy
@@ -14,14 +14,6 @@
         <array>
                 <dict>
                         <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
                         <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
                         <key>NSPrivacyAccessedAPITypeReasons</key>
                         <array>

--- a/GoogleUtilities/ISASwizzler/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/ISASwizzler/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/ISASwizzler/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/ISASwizzler/Resources/PrivacyInfo.xcprivacy
@@ -12,23 +12,6 @@
         </array>
         <key>NSPrivacyAccessedAPITypes</key>
         <array>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>1C8F.1</string>
-                                <string>C56D.1</string>
-                        </array>
-                </dict>
         </array>
 </dict>
 </plist>

--- a/GoogleUtilities/Logger/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Logger/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/Logger/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Logger/Resources/PrivacyInfo.xcprivacy
@@ -12,23 +12,6 @@
         </array>
         <key>NSPrivacyAccessedAPITypes</key>
         <array>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>1C8F.1</string>
-                                <string>C56D.1</string>
-                        </array>
-                </dict>
         </array>
 </dict>
 </plist>

--- a/GoogleUtilities/MethodSwizzler/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/MethodSwizzler/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/MethodSwizzler/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/MethodSwizzler/Resources/PrivacyInfo.xcprivacy
@@ -12,23 +12,6 @@
         </array>
         <key>NSPrivacyAccessedAPITypes</key>
         <array>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>1C8F.1</string>
-                                <string>C56D.1</string>
-                        </array>
-                </dict>
         </array>
 </dict>
 </plist>

--- a/GoogleUtilities/NSData+zlib/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/NSData+zlib/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/NSData+zlib/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/NSData+zlib/Resources/PrivacyInfo.xcprivacy
@@ -12,23 +12,6 @@
         </array>
         <key>NSPrivacyAccessedAPITypes</key>
         <array>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>1C8F.1</string>
-                                <string>C56D.1</string>
-                        </array>
-                </dict>
         </array>
 </dict>
 </plist>

--- a/GoogleUtilities/Network/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Network/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/Network/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Network/Resources/PrivacyInfo.xcprivacy
@@ -20,15 +20,6 @@
                                 <string>C617.1</string>
                         </array>
                 </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>1C8F.1</string>
-                                <string>C56D.1</string>
-                        </array>
-                </dict>
         </array>
 </dict>
 </plist>

--- a/GoogleUtilities/Reachability/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Reachability/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/Reachability/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Reachability/Resources/PrivacyInfo.xcprivacy
@@ -12,23 +12,6 @@
         </array>
         <key>NSPrivacyAccessedAPITypes</key>
         <array>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>1C8F.1</string>
-                                <string>C56D.1</string>
-                        </array>
-                </dict>
         </array>
 </dict>
 </plist>

--- a/GoogleUtilities/UserDefaults/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/UserDefaults/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                                <string>C56D.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/GoogleUtilities/UserDefaults/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/UserDefaults/Resources/PrivacyInfo.xcprivacy
@@ -14,14 +14,6 @@
         <array>
                 <dict>
                         <key>NSPrivacyAccessedAPIType</key>
-                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-                        <key>NSPrivacyAccessedAPITypeReasons</key>
-                        <array>
-                                <string>C617.1</string>
-                        </array>
-                </dict>
-                <dict>
-                        <key>NSPrivacyAccessedAPIType</key>
                         <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
                         <key>NSPrivacyAccessedAPITypeReasons</key>
                         <array>

--- a/Package.swift
+++ b/Package.swift
@@ -72,16 +72,10 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "GoogleUtilitiesPrivacy",
-      path: "GoogleUtilities/Privacy",
-      resources: [.process("Resources/PrivacyInfo.xcprivacy")]
-    ),
-    .target(
       name: "GoogleUtilities-AppDelegateSwizzler",
       dependencies: ["GoogleUtilities-Environment",
                      "GoogleUtilities-Logger",
-                     "GoogleUtilities-Network",
-                     "GoogleUtilitiesPrivacy"],
+                     "GoogleUtilities-Network"],
       path: "GoogleUtilities/AppDelegateSwizzler",
       exclude: ["README.md"],
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
@@ -94,9 +88,7 @@ let package = Package(
       name: "GoogleUtilities-Environment",
       dependencies: [
         .product(name: "FBLPromises", package: "Promises"),
-        "third-party-IsAppEncrypted",
-        "GoogleUtilitiesPrivacy",
-      ],
+        "third-party-IsAppEncrypted"],
       path: "GoogleUtilities/Environment",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
@@ -117,7 +109,7 @@ let package = Package(
 
     .target(
       name: "GoogleUtilities-Logger",
-      dependencies: ["GoogleUtilities-Environment", "GoogleUtilitiesPrivacy"],
+      dependencies: ["GoogleUtilities-Environment"],
       path: "GoogleUtilities/Logger",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
@@ -128,7 +120,7 @@ let package = Package(
 
     .target(
       name: "GoogleUtilities-ISASwizzler",
-      dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
+      dependencies: ["GoogleUtilities-Logger"],
       path: "GoogleUtilities/ISASwizzler",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
@@ -139,7 +131,7 @@ let package = Package(
 
     .target(
       name: "GoogleUtilities-MethodSwizzler",
-      dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
+      dependencies: ["GoogleUtilities-Logger"],
       path: "GoogleUtilities/MethodSwizzler",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
@@ -151,8 +143,7 @@ let package = Package(
       name: "GoogleUtilities-Network",
       dependencies: ["GoogleUtilities-Logger",
                      "GoogleUtilities-NSData",
-                     "GoogleUtilities-Reachability",
-                     "GoogleUtilitiesPrivacy"],
+                     "GoogleUtilities-Reachability"],
       path: "GoogleUtilities/Network",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
@@ -162,7 +153,7 @@ let package = Package(
     ),
     .target(
       name: "GoogleUtilities-NSData",
-      dependencies: ["GoogleUtilitiesPrivacy"],
+      dependencies: [],
       path: "GoogleUtilities/NSData+zlib",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
@@ -175,7 +166,7 @@ let package = Package(
     ),
     .target(
       name: "GoogleUtilities-Reachability",
-      dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
+      dependencies: ["GoogleUtilities-Logger"],
       path: "GoogleUtilities/Reachability",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
@@ -185,7 +176,7 @@ let package = Package(
     ),
     .target(
       name: "GoogleUtilities-UserDefaults",
-      dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
+      dependencies: ["GoogleUtilities-Logger"],
       path: "GoogleUtilities/UserDefaults",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",

--- a/Package.swift
+++ b/Package.swift
@@ -70,7 +70,6 @@ let package = Package(
       .revision("c5eeaa6dde7c308a5ce48ae4d4530462dd3a1110")
     ),
   ],
-  // TODO: Restructure directory structure to simplify the excludes here.
   targets: [
     .target(
       name: "GoogleUtilitiesPrivacy",
@@ -83,27 +82,12 @@ let package = Package(
                      "GoogleUtilities-Logger",
                      "GoogleUtilities-Network",
                      "GoogleUtilitiesPrivacy"],
-      path: "GoogleUtilities",
-      exclude: [
-        "AppDelegateSwizzler/README.md",
-        "Environment/",
-        "Network/",
-        "ISASwizzler/",
-        "Logger/",
-        "MethodSwizzler/",
-        "NSData+zlib/",
-        "Reachability",
-        "SwizzlerTestHelpers/",
-        "Tests",
-        "UserDefaults/",
-      ],
-      sources: [
-        "AppDelegateSwizzler/",
-        "Common/",
-      ],
-      publicHeadersPath: "AppDelegateSwizzler/Public",
+      path: "GoogleUtilities/AppDelegateSwizzler",
+      exclude: ["README.md"],
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
+      publicHeadersPath: "Public",
       cSettings: [
-        .headerSearchPath("../"),
+        .headerSearchPath("../../"),
       ]
     ),
     .target(
@@ -114,6 +98,7 @@ let package = Package(
         "GoogleUtilitiesPrivacy",
       ],
       path: "GoogleUtilities/Environment",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),
@@ -134,6 +119,7 @@ let package = Package(
       name: "GoogleUtilities-Logger",
       dependencies: ["GoogleUtilities-Environment", "GoogleUtilitiesPrivacy"],
       path: "GoogleUtilities/Logger",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),
@@ -144,6 +130,7 @@ let package = Package(
       name: "GoogleUtilities-ISASwizzler",
       dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
       path: "GoogleUtilities/ISASwizzler",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),
@@ -154,6 +141,7 @@ let package = Package(
       name: "GoogleUtilities-MethodSwizzler",
       dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
       path: "GoogleUtilities/MethodSwizzler",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),
@@ -166,6 +154,7 @@ let package = Package(
                      "GoogleUtilities-Reachability",
                      "GoogleUtilitiesPrivacy"],
       path: "GoogleUtilities/Network",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../.."),
@@ -175,6 +164,7 @@ let package = Package(
       name: "GoogleUtilities-NSData",
       dependencies: ["GoogleUtilitiesPrivacy"],
       path: "GoogleUtilities/NSData+zlib",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../.."),
@@ -187,6 +177,7 @@ let package = Package(
       name: "GoogleUtilities-Reachability",
       dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
       path: "GoogleUtilities/Reachability",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),
@@ -196,6 +187,7 @@ let package = Package(
       name: "GoogleUtilities-UserDefaults",
       dependencies: ["GoogleUtilities-Logger", "GoogleUtilitiesPrivacy"],
       path: "GoogleUtilities/UserDefaults",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),

--- a/Package.swift
+++ b/Package.swift
@@ -88,7 +88,8 @@ let package = Package(
       name: "GoogleUtilities-Environment",
       dependencies: [
         .product(name: "FBLPromises", package: "Promises"),
-        "third-party-IsAppEncrypted"],
+        "third-party-IsAppEncrypted",
+      ],
       path: "GoogleUtilities/Environment",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",


### PR DESCRIPTION
With this PR, the privacy manifest approach is as follows:
- [changed] SwiftPM library targets have corresponding, unique privacy manifests
- [unchanged] CocoaPods subspaces share dependency on a common, aggregated privacy manifest 