### PR TITLE
Fix Xcode 15 runtime warning

### DIFF
--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -145,25 +145,25 @@
     [self excludeFromBackupForURL:_uploadingFileURL];
 
     _sessionConfig = [self backgroundSessionConfigWithSessionID:_sessionID];
-    [self populateSessionConfig:_sessionConfig withRequest:request];
-    session = [NSURLSession sessionWithConfiguration:_sessionConfig
-                                            delegate:self
-                                       delegateQueue:[NSOperationQueue mainQueue]];
-    postRequestTask = [session uploadTaskWithRequest:request fromFile:_uploadingFileURL];
   } else {
     // If we cannot write to file, just send it in the foreground.
     _sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
-    [self populateSessionConfig:_sessionConfig withRequest:request];
-    session = [NSURLSession sessionWithConfiguration:_sessionConfig
-                                            delegate:self
-                                       delegateQueue:[NSOperationQueue mainQueue]];
-    // To avoid a runtime warning in Xcode 15 Beta 4, the given `URLRequest`
-    // should have a nil `HTTPBody`. To workaround this, the given `URLRequest`
-    // is copied and the `HTTPBody` data is removed.
-    NSData *givenRequestHTTPBody = [request.HTTPBody copy];
-    NSMutableURLRequest *requestWithoutHTTPBody = [request mutableCopy];
-    requestWithoutHTTPBody.HTTPBody = nil;
+  }
+  [self populateSessionConfig:_sessionConfig withRequest:request];
+  session = [NSURLSession sessionWithConfiguration:_sessionConfig
+                                          delegate:self
+                                     delegateQueue:[NSOperationQueue mainQueue]];
+  // To avoid a runtime warning in Xcode 15 Beta 4, the given `URLRequest`
+  // should have a nil `HTTPBody`. To workaround this, the given `URLRequest`
+  // is copied and the `HTTPBody` data is removed.
+  NSData *givenRequestHTTPBody = [request.HTTPBody copy];
+  NSMutableURLRequest *requestWithoutHTTPBody = [request mutableCopy];
+  requestWithoutHTTPBody.HTTPBody = nil;
 
+  if (didWriteFile) {
+    postRequestTask = [session uploadTaskWithRequest:requestWithoutHTTPBody
+                                            fromFile:_uploadingFileURL];
+  } else {
     postRequestTask = [session uploadTaskWithRequest:requestWithoutHTTPBody
                                             fromData:givenRequestHTTPBody];
   }

--- a/GoogleUtilities/Tests/Unit/Environment/NSURLSession+GULPromisesTests.m
+++ b/GoogleUtilities/Tests/Unit/Environment/NSURLSession+GULPromisesTests.m
@@ -71,8 +71,6 @@
   XCTAssertEqualObjects(taskPromise.value.HTTPBody, expectedBody);
 }
 
-// TODO: Since moving to Xcode 15, this test almost always fails on Catalyst.
-#if !TARGET_OS_MACCATALYST
 - (void)testDataTaskPromiseWithRequestError {
   NSURL *url = [NSURL URLWithString:@"https://localhost"];
   NSURLRequest *request = [NSURLRequest requestWithURL:url];
@@ -98,6 +96,5 @@
   XCTAssertEqualObjects(taskPromise.error, expectedError);
   XCTAssertNil(taskPromise.value);
 }
-#endif
 
 @end


### PR DESCRIPTION
A duplicate issue to the one resolved in #114 just in the `then` part of the same `if`

Also revert #157 since the Catalyst flake just moved to the previous test. Something about the last Promises test doesn't work?