### PR TITLE
Remove support for deprecated application:didReceiveRemoteNotification:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.0.0
+- Remove swizzling support for `application:didReceiveRemoteNotification:`.
+  Use `application:didReceiveRemoteNotification:fetchCompletionHandler:` instead. (#162)
+
 # 7.13.3
 - Rename parameter placeholder in `GULSecureCoding` unarchiving API to avoid
   conflict with keyword. (#152)

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -934,35 +934,6 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
 }
 #endif  // !TARGET_OS_WATCH && !TARGET_OS_OSX
 
-- (void)application:(GULApplication *)application
-    donor_didReceiveRemoteNotification:(NSDictionary *)userInfo {
-  SEL methodSelector = NSSelectorFromString(kGULDidReceiveRemoteNotificationSEL);
-  NSValue *didReceiveRemoteNotificationIMPPointer =
-      [GULAppDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
-  GULRealDidReceiveRemoteNotificationIMP didReceiveRemoteNotificationIMP =
-      [didReceiveRemoteNotificationIMPPointer pointerValue];
-
-  // Notify interceptors.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [GULAppDelegateSwizzler
-      notifyInterceptorsWithMethodSelector:methodSelector
-                                  callback:^(id<GULApplicationDelegate> interceptor) {
-                                    NSInvocation *invocation = [GULAppDelegateSwizzler
-                                        appDelegateInvocationForSelector:methodSelector];
-                                    [invocation setTarget:interceptor];
-                                    [invocation setSelector:methodSelector];
-                                    [invocation setArgument:(void *)(&application) atIndex:2];
-                                    [invocation setArgument:(void *)(&userInfo) atIndex:3];
-                                    [invocation invoke];
-                                  }];
-#pragma clang diagnostic pop
-  // Call the real implementation if the real App Delegate has any.
-  if (didReceiveRemoteNotificationIMP) {
-    didReceiveRemoteNotificationIMP(self, methodSelector, application, userInfo);
-  }
-}
-
 + (nullable NSInvocation *)appDelegateInvocationForSelector:(SEL)selector {
   struct objc_method_description methodDescription =
       protocol_getMethodDescription(@protocol(GULApplicationDelegate), selector, NO, YES);

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -106,8 +106,6 @@ static NSString *const kGULDidRegisterForRemoteNotificationsSEL =
     @"application:didRegisterForRemoteNotificationsWithDeviceToken:";
 static NSString *const kGULDidFailToRegisterForRemoteNotificationsSEL =
     @"application:didFailToRegisterForRemoteNotificationsWithError:";
-static NSString *const kGULDidReceiveRemoteNotificationSEL =
-    @"application:didReceiveRemoteNotification:";
 static NSString *const kGULDidReceiveRemoteNotificationWithCompletionSEL =
     @"application:didReceiveRemoteNotification:fetchCompletionHandler:";
 

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -499,38 +499,18 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
                               realClass:realClass
        storeDestinationImplementationTo:realImplementationsBySelector];
 
-  // For application:didReceiveRemoteNotification:
-  SEL didReceiveRemoteNotificationSEL = NSSelectorFromString(kGULDidReceiveRemoteNotificationSEL);
-  SEL didReceiveRemoteNotificationDonorSEL = @selector(application:
-                                donor_didReceiveRemoteNotification:);
-
-  [self proxyDestinationSelector:didReceiveRemoteNotificationSEL
-      implementationsFromSourceSelector:didReceiveRemoteNotificationDonorSEL
-                              fromClass:[GULAppDelegateSwizzler class]
-                                toClass:appDelegateSubClass
-                              realClass:realClass
-       storeDestinationImplementationTo:realImplementationsBySelector];
-
   // For application:didReceiveRemoteNotification:fetchCompletionHandler:
 #if !TARGET_OS_WATCH && !TARGET_OS_OSX
   SEL didReceiveRemoteNotificationWithCompletionSEL =
       NSSelectorFromString(kGULDidReceiveRemoteNotificationWithCompletionSEL);
   SEL didReceiveRemoteNotificationWithCompletionDonorSEL =
       @selector(application:donor_didReceiveRemoteNotification:fetchCompletionHandler:);
-  if ([appDelegate respondsToSelector:didReceiveRemoteNotificationWithCompletionSEL]) {
-    // Only add the application:didReceiveRemoteNotification:fetchCompletionHandler: method if
-    // the original AppDelegate implements it.
-    // This fixes a bug if an app only implements application:didReceiveRemoteNotification:
-    // (if we add the method with completion, iOS sees that one exists and does not call
-    // the method without the completion, which in this case is the only one the app implements).
-
-    [self proxyDestinationSelector:didReceiveRemoteNotificationWithCompletionSEL
-        implementationsFromSourceSelector:didReceiveRemoteNotificationWithCompletionDonorSEL
-                                fromClass:[GULAppDelegateSwizzler class]
-                                  toClass:appDelegateSubClass
-                                realClass:realClass
-         storeDestinationImplementationTo:realImplementationsBySelector];
-  }
+  [self proxyDestinationSelector:didReceiveRemoteNotificationWithCompletionSEL
+      implementationsFromSourceSelector:didReceiveRemoteNotificationWithCompletionDonorSEL
+                              fromClass:[GULAppDelegateSwizzler class]
+                                toClass:appDelegateSubClass
+                              realClass:realClass
+       storeDestinationImplementationTo:realImplementationsBySelector];
 #endif  // !TARGET_OS_WATCH && !TARGET_OS_OSX
 }
 


### PR DESCRIPTION
Now only `application:didReceiveRemoteNotification:fetchCompletionHandler:` is supported unconditionally.

Without removing the conditional around the new API, Firebase would not be able to drop support for the old API.

Part of the solution for https://github.com/firebase/firebase-ios-sdk/issues/11693

This is a breaking change and should wait for version 8.