### PR TITLE
[Infra] Disable NSURLSession+GULPromisesTests.m for Catalyst

### DIFF
--- a/GoogleUtilities/Tests/Unit/Environment/NSURLSession+GULPromisesTests.m
+++ b/GoogleUtilities/Tests/Unit/Environment/NSURLSession+GULPromisesTests.m
@@ -23,6 +23,8 @@
 #import "GoogleUtilities/Environment/Public/GoogleUtilities/GULURLSessionDataResponse.h"
 #import "GoogleUtilities/Environment/Public/GoogleUtilities/NSURLSession+GULPromises.h"
 
+#if !TARGET_OS_MACCATALYST
+
 @interface NSURLSession_GULPromisesTests : XCTestCase
 @property(nonatomic) NSURLSession *URLSession;
 @property(nonatomic) id URLSessionMock;
@@ -98,3 +100,5 @@
 }
 
 @end
+
+#endif  // !TARGET_OS_MACCATALYST


### PR DESCRIPTION
The promises tests consistently flake on catalyst. Weirdly, it's always the last test to run that flakes. 

Opened a bug to track: https://github.com/google/GoogleUtilities/issues/170