### PR TITLE
Use os log

### DIFF
--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -168,7 +168,7 @@ void GULLogBasic(GULLoggerLevel level,
   }
   logMsg = [NSString stringWithFormat:@"%@ - %@[%@] %@", sVersion, service, messageCode, logMsg];
   dispatch_async(sGULClientQueue, ^{
-    os_log_with_type(sLogObject, convertLoggerLevel(level), "%@", logMsg);
+    os_log_with_type(sLogObject, convertLoggerLevel(level), "%{public}@", logMsg);
   });
 }
 

--- a/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
@@ -20,17 +20,17 @@
 
 #import "GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h"
 
-#import <asl.h>
+#import <OSLog/OSLog.h>
 
 extern const char *kGULLoggerASLClientFacilityName;
 
 extern void GULResetLogger(void);
 
-extern aslclient getGULLoggerClient(void);
-
 extern dispatch_queue_t getGULClientQueue(void);
 
 extern BOOL getGULLoggerDebugMode(void);
+
+extern os_log_type_t convertLoggerLevel(GULLoggerLevel);
 
 static NSString *const kMessageCode = @"I-COR000001";
 
@@ -110,11 +110,11 @@ static NSString *const kMessageCode = @"I-COR000001";
 // them in GULLoggerLevel.h since we cannot include <asl.h> (see b/34976089 for more details).
 // This test ensures the constants match.
 - (void)testGULLoggerLevelValues {
-  XCTAssertEqual(GULLoggerLevelError, ASL_LEVEL_ERR);
-  XCTAssertEqual(GULLoggerLevelWarning, ASL_LEVEL_WARNING);
-  XCTAssertEqual(GULLoggerLevelNotice, ASL_LEVEL_NOTICE);
-  XCTAssertEqual(GULLoggerLevelInfo, ASL_LEVEL_INFO);
-  XCTAssertEqual(GULLoggerLevelDebug, ASL_LEVEL_DEBUG);
+  XCTAssertEqual(convertLoggerLevel(GULLoggerLevelError), OS_LOG_TYPE_ERROR);
+  XCTAssertEqual(convertLoggerLevel(GULLoggerLevelWarning), OS_LOG_TYPE_DEFAULT);
+  XCTAssertEqual(convertLoggerLevel(GULLoggerLevelNotice), OS_LOG_TYPE_DEFAULT);
+  XCTAssertEqual(convertLoggerLevel(GULLoggerLevelInfo), OS_LOG_TYPE_INFO);
+  XCTAssertEqual(convertLoggerLevel(GULLoggerLevelDebug), OS_LOG_TYPE_DEBUG);
 }
 
 - (void)testGULGetLoggerLevel {


### PR DESCRIPTION
Hello!

We were recently looking to gather logs programmatically from some Firebase SDKs, and found that they were making use of the logger within this repository. While attempting to get the log reader working with ASL, and having difficulties, I found it was easier to instead migrate this repository to OSLog, which is the way forward from Apple's perspective.

I did not change the public interface since other SDKs depended on those function signatures, and instead opted to just modify the functionality under the hood. I tried to keep existing functions working as best as I could, while removing anything that was no longer necessary.

I understand that this isn't likely a complete product if you want to actually release this since the function names still reference ASL, but hopefully it's a good starting point.