### PR TITLE
Migrate from `ASL` to `OSLog`

### DIFF
--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -216,14 +216,14 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
            @"AppDelegateProxy interceptor does not conform to UIApplicationDelegate");
 
   if (!interceptor) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling000],
                 @"AppDelegateProxy cannot add nil interceptor.");
     return nil;
   }
   if (![interceptor conformsToProtocol:@protocol(GULApplicationDelegate)]) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling001],
                 @"AppDelegateProxy interceptor does not conform to UIApplicationDelegate");
@@ -233,7 +233,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // The ID should be the same given the same interceptor object.
   NSString *interceptorID = [NSString stringWithFormat:@"%@%p", kGULAppDelegatePrefix, interceptor];
   if (!interceptorID.length) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling002],
                 @"AppDelegateProxy cannot create Interceptor ID.");
@@ -251,7 +251,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
            @"AppDelegateProxy cannot unregister empty interceptor ID.");
 
   if (!interceptorID) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling003],
                 @"AppDelegateProxy cannot unregister empty interceptor ID.");
@@ -260,7 +260,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
 
   GULZeroingWeakContainer *weakContainer = [GULAppDelegateSwizzler interceptors][interceptorID];
   if (!weakContainer.object) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling004],
                 @"AppDelegateProxy cannot unregister interceptor that was not registered. "
@@ -343,7 +343,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
       [NSString stringWithFormat:@"%@-%@", classNameWithPrefix, [NSUUID UUID].UUIDString];
 
   if (NSClassFromString(newClassName)) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling005],
                 @"Cannot create a proxy for App Delegate. Subclass already exists. Original Class: "
@@ -356,7 +356,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // size.
   Class appDelegateSubClass = objc_allocateClassPair(realClass, newClassName.UTF8String, 0);
   if (appDelegateSubClass == Nil) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling006],
                 @"Cannot create a proxy for App Delegate. Subclass already exists. Original Class: "
@@ -436,7 +436,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // cannot have more ivars/properties than its superclass since it will cause an offset in memory
   // that can lead to overwriting the isa of an object in the next frame.
   if (class_getInstanceSize(realClass) != class_getInstanceSize(appDelegateSubClass)) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling007],
                 @"Cannot create subclass of App Delegate, because the created subclass is not the "
@@ -449,7 +449,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // Make the newly created class to be the subclass of the real App Delegate class.
   objc_registerClassPair(appDelegateSubClass);
   if (object_setClass(appDelegate, appDelegateSubClass)) {
-    GULLogDebug(kGULLoggerSwizzler, NO,
+    GULLogDebug(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling008],
                 @"Successfully created App Delegate Proxy automatically. To disable the "
@@ -604,7 +604,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   IMP methodIMP = method_getImplementation(method);
   const char *types = method_getTypeEncoding(method);
   if (!class_addMethod(toClass, destinationSelector, methodIMP, types)) {
-    GULLogWarning(kGULLoggerSwizzler, NO,
+    GULLogWarning(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                   [NSString stringWithFormat:@"I-SWZ%06ld",
                                              (long)kGULSwizzlerMessageCodeAppDelegateSwizzling009],
                   @"Cannot copy method to destination selector %@ as it already exists",
@@ -641,7 +641,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
     id interceptor = interceptorContainer.object;
     if (!interceptor) {
       GULLogWarning(
-          kGULLoggerSwizzler, NO,
+          kGULLogSubsystem, kGULLoggerSwizzler, NO,
           [NSString
               stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeAppDelegateSwizzling010],
           @"AppDelegateProxy cannot find interceptor with ID %@. Removing the interceptor.", key);
@@ -946,7 +946,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
 + (void)proxyAppDelegate:(id<GULApplicationDelegate>)appDelegate {
   if (![appDelegate conformsToProtocol:@protocol(GULApplicationDelegate)]) {
     GULLogNotice(
-        kGULLoggerSwizzler, NO,
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
                              (long)kGULSwizzlerMessageCodeAppDelegateSwizzlingInvalidAppDelegate],
@@ -958,7 +958,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   id<GULApplicationDelegate> originalDelegate = appDelegate;
   // Do not create a subclass if it is not enabled.
   if (![GULAppDelegateSwizzler isAppDelegateProxyEnabled]) {
-    GULLogNotice(kGULLoggerSwizzler, NO,
+    GULLogNotice(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                  [NSString stringWithFormat:@"I-SWZ%06ld",
                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling011],
                  @"App Delegate Proxy is disabled. %@",
@@ -967,7 +967,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   }
   // Do not accept nil delegate.
   if (!originalDelegate) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling012],
                 @"Cannot create App Delegate Proxy because App Delegate instance is nil. %@",
@@ -980,7 +980,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
     gAppDelegateSubclass = [self createSubclassWithObject:originalDelegate];
     [self reassignAppDelegate];
   } @catch (NSException *exception) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling013],
                 @"Cannot create App Delegate Proxy. %@",

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -216,27 +216,27 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
            @"AppDelegateProxy interceptor does not conform to UIApplicationDelegate");
 
   if (!interceptor) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling000],
-                @"AppDelegateProxy cannot add nil interceptor.");
+    GULOSLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling000],
+                  @"AppDelegateProxy cannot add nil interceptor.");
     return nil;
   }
   if (![interceptor conformsToProtocol:@protocol(GULApplicationDelegate)]) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling001],
-                @"AppDelegateProxy interceptor does not conform to UIApplicationDelegate");
+    GULOSLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling001],
+                  @"AppDelegateProxy interceptor does not conform to UIApplicationDelegate");
     return nil;
   }
 
   // The ID should be the same given the same interceptor object.
   NSString *interceptorID = [NSString stringWithFormat:@"%@%p", kGULAppDelegatePrefix, interceptor];
   if (!interceptorID.length) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling002],
-                @"AppDelegateProxy cannot create Interceptor ID.");
+    GULOSLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling002],
+                  @"AppDelegateProxy cannot create Interceptor ID.");
     return nil;
   }
   GULZeroingWeakContainer *weakObject = [[GULZeroingWeakContainer alloc] init];
@@ -251,21 +251,21 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
            @"AppDelegateProxy cannot unregister empty interceptor ID.");
 
   if (!interceptorID) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling003],
-                @"AppDelegateProxy cannot unregister empty interceptor ID.");
+    GULOSLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling003],
+                  @"AppDelegateProxy cannot unregister empty interceptor ID.");
     return;
   }
 
   GULZeroingWeakContainer *weakContainer = [GULAppDelegateSwizzler interceptors][interceptorID];
   if (!weakContainer.object) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling004],
-                @"AppDelegateProxy cannot unregister interceptor that was not registered. "
-                 "Interceptor ID %@",
-                interceptorID);
+    GULOSLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling004],
+                  @"AppDelegateProxy cannot unregister interceptor that was not registered. "
+                   "Interceptor ID %@",
+                  interceptorID);
     return;
   }
 
@@ -343,12 +343,13 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
       [NSString stringWithFormat:@"%@-%@", classNameWithPrefix, [NSUUID UUID].UUIDString];
 
   if (NSClassFromString(newClassName)) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling005],
-                @"Cannot create a proxy for App Delegate. Subclass already exists. Original Class: "
-                @"%@, subclass: %@",
-                NSStringFromClass(realClass), newClassName);
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeAppDelegateSwizzling005],
+        @"Cannot create a proxy for App Delegate. Subclass already exists. Original Class: "
+        @"%@, subclass: %@",
+        NSStringFromClass(realClass), newClassName);
     return nil;
   }
 
@@ -356,12 +357,13 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // size.
   Class appDelegateSubClass = objc_allocateClassPair(realClass, newClassName.UTF8String, 0);
   if (appDelegateSubClass == Nil) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling006],
-                @"Cannot create a proxy for App Delegate. Subclass already exists. Original Class: "
-                @"%@, subclass: Nil",
-                NSStringFromClass(realClass));
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeAppDelegateSwizzling006],
+        @"Cannot create a proxy for App Delegate. Subclass already exists. Original Class: "
+        @"%@, subclass: Nil",
+        NSStringFromClass(realClass));
     return nil;
   }
 
@@ -436,12 +438,13 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // cannot have more ivars/properties than its superclass since it will cause an offset in memory
   // that can lead to overwriting the isa of an object in the next frame.
   if (class_getInstanceSize(realClass) != class_getInstanceSize(appDelegateSubClass)) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling007],
-                @"Cannot create subclass of App Delegate, because the created subclass is not the "
-                @"same size. %@",
-                NSStringFromClass(realClass));
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeAppDelegateSwizzling007],
+        @"Cannot create subclass of App Delegate, because the created subclass is not the "
+        @"same size. %@",
+        NSStringFromClass(realClass));
     NSAssert(NO, @"Classes must be the same size to swizzle isa");
     return nil;
   }
@@ -449,12 +452,12 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // Make the newly created class to be the subclass of the real App Delegate class.
   objc_registerClassPair(appDelegateSubClass);
   if (object_setClass(appDelegate, appDelegateSubClass)) {
-    GULLogDebug(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling008],
-                @"Successfully created App Delegate Proxy automatically. To disable the "
-                @"proxy, set the flag %@ to NO (Boolean) in the Info.plist",
-                [GULAppDelegateSwizzler correctAppDelegateProxyKey]);
+    GULOSLogDebug(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling008],
+                  @"Successfully created App Delegate Proxy automatically. To disable the "
+                  @"proxy, set the flag %@ to NO (Boolean) in the Info.plist",
+                  [GULAppDelegateSwizzler correctAppDelegateProxyKey]);
   }
 
   return appDelegateSubClass;
@@ -604,11 +607,12 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   IMP methodIMP = method_getImplementation(method);
   const char *types = method_getTypeEncoding(method);
   if (!class_addMethod(toClass, destinationSelector, methodIMP, types)) {
-    GULLogWarning(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                  [NSString stringWithFormat:@"I-SWZ%06ld",
-                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling009],
-                  @"Cannot copy method to destination selector %@ as it already exists",
-                  NSStringFromSelector(destinationSelector));
+    GULOSLogWarning(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeAppDelegateSwizzling009],
+        @"Cannot copy method to destination selector %@ as it already exists",
+        NSStringFromSelector(destinationSelector));
   }
 }
 
@@ -640,7 +644,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
     GULZeroingWeakContainer *interceptorContainer = obj;
     id interceptor = interceptorContainer.object;
     if (!interceptor) {
-      GULLogWarning(
+      GULOSLogWarning(
           kGULLogSubsystem, kGULLoggerSwizzler, NO,
           [NSString
               stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeAppDelegateSwizzling010],
@@ -945,7 +949,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
 
 + (void)proxyAppDelegate:(id<GULApplicationDelegate>)appDelegate {
   if (![appDelegate conformsToProtocol:@protocol(GULApplicationDelegate)]) {
-    GULLogNotice(
+    GULOSLogNotice(
         kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
@@ -958,20 +962,20 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   id<GULApplicationDelegate> originalDelegate = appDelegate;
   // Do not create a subclass if it is not enabled.
   if (![GULAppDelegateSwizzler isAppDelegateProxyEnabled]) {
-    GULLogNotice(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                 [NSString stringWithFormat:@"I-SWZ%06ld",
-                                            (long)kGULSwizzlerMessageCodeAppDelegateSwizzling011],
-                 @"App Delegate Proxy is disabled. %@",
-                 [GULAppDelegateSwizzler correctAlternativeWhenAppDelegateProxyNotCreated]);
+    GULOSLogNotice(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                   [NSString stringWithFormat:@"I-SWZ%06ld",
+                                              (long)kGULSwizzlerMessageCodeAppDelegateSwizzling011],
+                   @"App Delegate Proxy is disabled. %@",
+                   [GULAppDelegateSwizzler correctAlternativeWhenAppDelegateProxyNotCreated]);
     return;
   }
   // Do not accept nil delegate.
   if (!originalDelegate) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling012],
-                @"Cannot create App Delegate Proxy because App Delegate instance is nil. %@",
-                [GULAppDelegateSwizzler correctAlternativeWhenAppDelegateProxyNotCreated]);
+    GULOSLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling012],
+                  @"Cannot create App Delegate Proxy because App Delegate instance is nil. %@",
+                  [GULAppDelegateSwizzler correctAlternativeWhenAppDelegateProxyNotCreated]);
     return;
   }
 
@@ -980,11 +984,11 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
     gAppDelegateSubclass = [self createSubclassWithObject:originalDelegate];
     [self reassignAppDelegate];
   } @catch (NSException *exception) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeAppDelegateSwizzling013],
-                @"Cannot create App Delegate Proxy. %@",
-                [GULAppDelegateSwizzler correctAlternativeWhenAppDelegateProxyNotCreated]);
+    GULOSLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
+                  [NSString stringWithFormat:@"I-SWZ%06ld",
+                                             (long)kGULSwizzlerMessageCodeAppDelegateSwizzling013],
+                  @"Cannot create App Delegate Proxy. %@",
+                  [GULAppDelegateSwizzler correctAlternativeWhenAppDelegateProxyNotCreated]);
     return;
   }
 }

--- a/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
@@ -108,14 +108,14 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
            @"SceneDelegateProxy interceptor does not conform to UIApplicationDelegate");
 
   if (!interceptor) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling000],
                 @"SceneDelegateProxy cannot add nil interceptor.");
     return nil;
   }
   if (![interceptor conformsToProtocol:@protocol(UISceneDelegate)]) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling001],
                 @"SceneDelegateProxy interceptor does not conform to UIApplicationDelegate");
@@ -126,7 +126,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   NSString *interceptorID =
       [NSString stringWithFormat:@"%@%p", kGULSceneDelegatePrefix, interceptor];
   if (!interceptorID.length) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling002],
                 @"SceneDelegateProxy cannot create Interceptor ID.");
@@ -144,7 +144,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
            @"SceneDelegateProxy cannot unregister empty interceptor ID.");
 
   if (!interceptorID) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling003],
                 @"SceneDelegateProxy cannot unregister empty interceptor ID.");
@@ -154,7 +154,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   GULSceneZeroingWeakContainer *weakContainer =
       [GULSceneDelegateSwizzler interceptors][interceptorID];
   if (!weakContainer.object) {
-    GULLogError(kGULLoggerSwizzler, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                 [NSString stringWithFormat:@"I-SWZ%06ld",
                                            (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling004],
                 @"SceneDelegateProxy cannot unregister interceptor that was not registered. "
@@ -248,7 +248,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   const char *types = method_getTypeEncoding(method);
   if (!class_addMethod(toClass, destinationSelector, methodIMP, types)) {
     GULLogWarning(
-        kGULLoggerSwizzler, NO,
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling009],
         @"Cannot copy method to destination selector %@ as it already exists",
@@ -286,7 +286,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
     id interceptor = interceptorContainer.object;
     if (!interceptor) {
       GULLogWarning(
-          kGULLoggerSwizzler, NO,
+          kGULLogSubsystem, kGULLoggerSwizzler, NO,
           [NSString stringWithFormat:@"I-SWZ%06ld",
                                      (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling010],
           @"SceneDelegateProxy cannot find interceptor with ID %@. Removing the interceptor.", key);
@@ -352,7 +352,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
 
   if (NSClassFromString(newClassName)) {
     GULLogError(
-        kGULLoggerSwizzler, NO,
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
                              (long)
@@ -368,7 +368,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   Class sceneDelegateSubClass = objc_allocateClassPair(realClass, newClassName.UTF8String, 0);
   if (sceneDelegateSubClass == Nil) {
     GULLogError(
-        kGULLoggerSwizzler, NO,
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
                              (long)
@@ -402,7 +402,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   // that can lead to overwriting the isa of an object in the next frame.
   if (class_getInstanceSize(realClass) != class_getInstanceSize(sceneDelegateSubClass)) {
     GULLogError(
-        kGULLoggerSwizzler, NO,
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
                              (long)
@@ -418,7 +418,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   objc_registerClassPair(sceneDelegateSubClass);
   if (object_setClass(scene.delegate, sceneDelegateSubClass)) {
     GULLogDebug(
-        kGULLoggerSwizzler, NO,
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
                              (long)

--- a/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
@@ -108,17 +108,19 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
            @"SceneDelegateProxy interceptor does not conform to UIApplicationDelegate");
 
   if (!interceptor) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling000],
-                @"SceneDelegateProxy cannot add nil interceptor.");
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling000],
+        @"SceneDelegateProxy cannot add nil interceptor.");
     return nil;
   }
   if (![interceptor conformsToProtocol:@protocol(UISceneDelegate)]) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling001],
-                @"SceneDelegateProxy interceptor does not conform to UIApplicationDelegate");
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling001],
+        @"SceneDelegateProxy interceptor does not conform to UIApplicationDelegate");
     return nil;
   }
 
@@ -126,10 +128,11 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   NSString *interceptorID =
       [NSString stringWithFormat:@"%@%p", kGULSceneDelegatePrefix, interceptor];
   if (!interceptorID.length) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling002],
-                @"SceneDelegateProxy cannot create Interceptor ID.");
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling002],
+        @"SceneDelegateProxy cannot create Interceptor ID.");
     return nil;
   }
   GULSceneZeroingWeakContainer *weakObject = [[GULSceneZeroingWeakContainer alloc] init];
@@ -144,22 +147,24 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
            @"SceneDelegateProxy cannot unregister empty interceptor ID.");
 
   if (!interceptorID) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling003],
-                @"SceneDelegateProxy cannot unregister empty interceptor ID.");
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling003],
+        @"SceneDelegateProxy cannot unregister empty interceptor ID.");
     return;
   }
 
   GULSceneZeroingWeakContainer *weakContainer =
       [GULSceneDelegateSwizzler interceptors][interceptorID];
   if (!weakContainer.object) {
-    GULLogError(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                [NSString stringWithFormat:@"I-SWZ%06ld",
-                                           (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling004],
-                @"SceneDelegateProxy cannot unregister interceptor that was not registered. "
-                 "Interceptor ID %@",
-                interceptorID);
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerSwizzler, NO,
+        [NSString
+            stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling004],
+        @"SceneDelegateProxy cannot unregister interceptor that was not registered. "
+         "Interceptor ID %@",
+        interceptorID);
     return;
   }
 
@@ -247,7 +252,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   IMP methodIMP = method_getImplementation(method);
   const char *types = method_getTypeEncoding(method);
   if (!class_addMethod(toClass, destinationSelector, methodIMP, types)) {
-    GULLogWarning(
+    GULOSLogWarning(
         kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling009],
@@ -285,7 +290,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
     GULSceneZeroingWeakContainer *interceptorContainer = obj;
     id interceptor = interceptorContainer.object;
     if (!interceptor) {
-      GULLogWarning(
+      GULOSLogWarning(
           kGULLogSubsystem, kGULLoggerSwizzler, NO,
           [NSString stringWithFormat:@"I-SWZ%06ld",
                                      (long)kGULSwizzlerMessageCodeSceneDelegateSwizzling010],
@@ -351,7 +356,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
       [NSString stringWithFormat:@"%@-%@", classNameWithPrefix, [NSUUID UUID].UUIDString];
 
   if (NSClassFromString(newClassName)) {
-    GULLogError(
+    GULOSLogError(
         kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
@@ -367,7 +372,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   // size.
   Class sceneDelegateSubClass = objc_allocateClassPair(realClass, newClassName.UTF8String, 0);
   if (sceneDelegateSubClass == Nil) {
-    GULLogError(
+    GULOSLogError(
         kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
@@ -401,7 +406,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   // cannot have more ivars/properties than its superclass since it will cause an offset in memory
   // that can lead to overwriting the isa of an object in the next frame.
   if (class_getInstanceSize(realClass) != class_getInstanceSize(sceneDelegateSubClass)) {
-    GULLogError(
+    GULOSLogError(
         kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",
@@ -417,7 +422,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   // Make the newly created class to be the subclass of the real Scene Delegate class.
   objc_registerClassPair(sceneDelegateSubClass);
   if (object_setClass(scene.delegate, sceneDelegateSubClass)) {
-    GULLogDebug(
+    GULOSLogDebug(
         kGULLogSubsystem, kGULLoggerSwizzler, NO,
         [NSString
             stringWithFormat:@"I-SWZ%06ld",

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -139,7 +139,7 @@ os_log_type_t GULLoggerLevelToOSLogType(GULLoggerLevel level) {
 
 void GULOSLogBasic(GULLoggerLevel level,
                    NSString *subsystem,
-                   GULLoggerService category,
+                   NSString *category,
                    BOOL forceLog,
                    NSString *messageCode,
                    NSString *message,
@@ -222,14 +222,14 @@ GUL_LOGGING_FUNCTION(Debug)
  * Calling GULLogDebug({service}, @"I-XYZ000001", @"Configure succeed.") shows:
  * yyyy-mm-dd hh:mm:ss.SSS sender[PID] <Debug> [{service}][I-XYZ000001] Configure succeed.
  */
-#define GUL_LOGGING_FUNCTION(level)                                                        \
-  void GULOSLog##level(NSString *subsystem, GULLoggerService category, BOOL force,         \
-                       NSString *messageCode, NSString *message, ...) {                    \
-    va_list args_ptr;                                                                      \
-    va_start(args_ptr, message);                                                           \
-    GULOSLogBasic(GULLoggerLevel##level, subsystem, category, force, messageCode, message, \
-                  args_ptr);                                                               \
-    va_end(args_ptr);                                                                      \
+#define GUL_LOGGING_FUNCTION(level)                                                                \
+  void GULOSLog##level(NSString *subsystem, NSString *category, BOOL force, NSString *messageCode, \
+                       NSString *message, ...) {                                                   \
+    va_list args_ptr;                                                                              \
+    va_start(args_ptr, message);                                                                   \
+    GULOSLogBasic(GULLoggerLevel##level, subsystem, category, force, messageCode, message,         \
+                  args_ptr);                                                                       \
+    va_end(args_ptr);                                                                              \
   }
 
 GUL_LOGGING_FUNCTION(Error)

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * The services used in the logger.
+ *
+ * DEPRECATED; use NSString instead.
  */
 typedef NSString *const GULLoggerService;
 
@@ -87,7 +89,7 @@ extern void GULLoggerRegisterVersion(NSString *version);
  */
 extern void GULOSLogBasic(GULLoggerLevel level,
                           NSString *subsystem,
-                          GULLoggerService category,
+                          NSString *category,
                           BOOL forceLog,
                           NSString *messageCode,
                           NSString *message,
@@ -225,7 +227,7 @@ extern void GULOSLogDebug(NSString *subsystem,
 ///     a format string; optional if `message` is not a format string.
 + (void)logWithLevel:(GULLoggerLevel)level
            subsystem:(NSString *)subsystem
-            category:(GULLoggerService)category
+            category:(NSString *)category
          messageCode:(NSString *)messageCode
              message:(NSString *)message
            arguments:(va_list)args;

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
@@ -29,13 +29,12 @@ typedef NSString *const GULLoggerService;
 extern "C" {
 #endif  // __cplusplus
 
+extern NSString *const kGULLogSubsystem;
+
 /**
  * Initialize GULLogger.
  */
 extern void GULLoggerInitialize(void);
-
-extern void GULLoggerInitializeASL(void)
-    DEPRECATED_MSG_ATTRIBUTE("Use GULLoggerInitialize instead.");
 
 /**
  * Override log level to Debug.
@@ -80,7 +79,8 @@ extern void GULLoggerRegisterVersion(NSString *version);
  *            string.
  */
 extern void GULLogBasic(GULLoggerLevel level,
-                        GULLoggerService service,
+                        NSString *subsystem,
+                        GULLoggerService category,
                         BOOL forceLog,
                         NSString *messageCode,
                         NSString *message,
@@ -106,31 +106,36 @@ extern void GULLogBasic(GULLoggerLevel level,
  * Example usage:
  * GULLogError(kGULLoggerCore, @"I-COR000001", @"Configuration of %@ failed.", app.name);
  */
-extern void GULLogError(GULLoggerService service,
+extern void GULLogError(NSString *subsystem,
+                        GULLoggerService category,
                         BOOL force,
                         NSString *messageCode,
                         NSString *message,
-                        ...) NS_FORMAT_FUNCTION(4, 5);
-extern void GULLogWarning(GULLoggerService service,
+                        ...) NS_FORMAT_FUNCTION(5, 6);
+extern void GULLogWarning(NSString *subsystem,
+                          GULLoggerService category,
                           BOOL force,
                           NSString *messageCode,
                           NSString *message,
-                          ...) NS_FORMAT_FUNCTION(4, 5);
-extern void GULLogNotice(GULLoggerService service,
+                          ...) NS_FORMAT_FUNCTION(5, 6);
+extern void GULLogNotice(NSString *subsystem,
+                         GULLoggerService category,
                          BOOL force,
                          NSString *messageCode,
                          NSString *message,
-                         ...) NS_FORMAT_FUNCTION(4, 5);
-extern void GULLogInfo(GULLoggerService service,
+                         ...) NS_FORMAT_FUNCTION(5, 6);
+extern void GULLogInfo(NSString *subsystem,
+                       GULLoggerService category,
                        BOOL force,
                        NSString *messageCode,
                        NSString *message,
-                       ...) NS_FORMAT_FUNCTION(4, 5);
-extern void GULLogDebug(GULLoggerService service,
+                       ...) NS_FORMAT_FUNCTION(5, 6);
+extern void GULLogDebug(NSString *subsystem,
+                        GULLoggerService category,
                         BOOL force,
                         NSString *messageCode,
                         NSString *message,
-                        ...) NS_FORMAT_FUNCTION(4, 5);
+                        ...) NS_FORMAT_FUNCTION(5, 6);
 
 #ifdef __cplusplus
 }  // extern "C"
@@ -138,24 +143,25 @@ extern void GULLogDebug(GULLoggerService service,
 
 @interface GULLoggerWrapper : NSObject
 
-/**
- * Objective-C wrapper for GULLogBasic to allow weak linking to GULLogger
- * (required) log level (one of the GULLoggerLevel enum values).
- * (required) service name of type GULLoggerService.
- * (required) message code starting with "I-" which means iOS, followed by a capitalized
- *            three-character service identifier and a six digit integer message ID that is unique
- *            within the service.
- *            An example of the message code is @"I-COR000001".
- * (required) message string which can be a format string.
- * (optional) variable arguments list obtained from calling va_start, used when message is a format
- *            string.
- */
-
+/// Objective-C wrapper for `GULLogBasic` to allow weak linking to `GULLogger`.
+///
+/// - Parameters:
+///   - level: The log level (one of the `GULLoggerLevel` enum values).
+///   - subsystem: An identifier for the subsystem performing logging, e.g., `com.example.logger`.
+///   - category: The category name within the `subsystem` to group related messages, e.g.,
+///     `[GoogleUtilities/Example]`.
+///   - messageCode: The message code starting with "I-" which means iOS, followed by a capitalized
+///     three-character service identifier and a six digit integer message ID that is unique within
+///     the service. An example of the message code is @"I-COR000001".
+///   - message: The message to log, which may be a format string.
+///   - arguments: The variable arguments list obtained from calling va_start, used when message is
+///     a format string; optional if `message` is not a format string.
 + (void)logWithLevel:(GULLoggerLevel)level
-         withService:(GULLoggerService)service
-            withCode:(NSString *)messageCode
-         withMessage:(NSString *)message
-            withArgs:(va_list)args;
+           subsystem:(NSString *)subsystem
+            category:(GULLoggerService)category
+         messageCode:(NSString *)messageCode
+             message:(NSString *)message
+           arguments:(va_list)args;
 
 @end
 

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
@@ -29,6 +29,7 @@ typedef NSString *const GULLoggerService;
 extern "C" {
 #endif  // __cplusplus
 
+/// DEPRECATED; provide a relevant subsystem name rather than using default.
 extern NSString *const kGULLogSubsystem;
 
 /// Initialize GULLogger.
@@ -36,16 +37,18 @@ extern void GULLoggerInitialize(void);
 
 /// Initialize GULLogger.
 ///
-/// The Apple System Log (ASL) in Google Utilities Logger has been replaced by OSLog. This function
-/// is deprecated and simply calls its replacement `GULLoggerInitialize`.
-extern void GULLoggerInitializeASL(void)
-    DEPRECATED_MSG_ATTRIBUTE("Replaced by `GULLoggerInitialize`.");
+/// The Apple System Log (ASL) in Google Utilities Logger has been replaced by OSLog.
+///
+/// DEPRECATED; simply calls its replacement `GULLoggerInitialize`.
+extern void GULLoggerInitializeASL(void);
 
 /// Override log level to Debug.
 void GULLoggerForceDebug(void);
 
 /// Turn on logging to STDERR.
-extern void GULLoggerEnableSTDERR(void) DEPRECATED_MSG_ATTRIBUTE("This function is a no-op.");
+///
+/// DEPRECATED; this function is a no-op.
+extern void GULLoggerEnableSTDERR(void);
 
 /// Gets the current `GULLoggerLevel`.
 extern GULLoggerLevel GULGetLoggerLevel(void);
@@ -109,6 +112,8 @@ extern void GULOSLogBasic(GULLoggerLevel level,
  * (required) message string which can be a format string.
  * (optional) variable arguments list obtained from calling va_start, used when message is a format
  *            string.
+ *
+ * DEPRECATED; replaced by `GULOSLogBasic`.
  */
 extern void GULLogBasic(GULLoggerLevel level,
                         GULLoggerService service,
@@ -122,7 +127,7 @@ extern void GULLogBasic(GULLoggerLevel level,
 #else
                         va_list _Nullable args_ptr
 #endif
-                        ) DEPRECATED_MSG_ATTRIBUTE("Replaced by `GULOSLogBasic`.");
+);
 
 /**
  * The following functions accept the following parameters in order:
@@ -136,6 +141,8 @@ extern void GULLogBasic(GULLoggerLevel level,
  * (optional) the list of arguments to substitute into the format string.
  * Example usage:
  * GULLogError(kGULLoggerCore, @"I-COR000001", @"Configuration of %@ failed.", app.name);
+ *
+ * DEPRECATED; replaced by `GULOSLogError`, `GULOSLogWarning`, etc.
  */
 extern void GULLogError(
     GULLoggerService service, BOOL force, NSString *messageCode, NSString *message, ...)
@@ -234,14 +241,14 @@ extern void GULOSLogDebug(NSString *subsystem,
  * (required) message string which can be a format string.
  * (optional) variable arguments list obtained from calling va_start, used when message is a format
  *            string.
+ *
+ *  DEPRECATED; replaced by `logWithLevel:subsystem:category:messageCode:message:arguments:`.
  */
 + (void)logWithLevel:(GULLoggerLevel)level
          withService:(GULLoggerService)service
             withCode:(NSString *)messageCode
          withMessage:(NSString *)message
-            withArgs:(va_list)args
-    DEPRECATED_MSG_ATTRIBUTE(
-        "Replaced by `logWithLevel:subsystem:category:messageCode:message:arguments:`.");
+            withArgs:(va_list)args;
 
 @end
 

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
@@ -32,17 +32,15 @@ extern "C" {
 /**
  * Initialize GULLogger.
  */
-extern void GULLoggerInitializeASL(void);
+extern void GULLoggerInitialize(void);
+
+extern void GULLoggerInitializeASL(void)
+    DEPRECATED_MSG_ATTRIBUTE("Use GULLoggerInitialize instead.");
 
 /**
  * Override log level to Debug.
  */
 void GULLoggerForceDebug(void);
-
-/**
- * Turn on logging to STDERR.
- */
-extern void GULLoggerEnableSTDERR(void);
 
 /**
  * Gets the current GULLoggerLevel.

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULLoggerLevel.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULLoggerLevel.h
@@ -18,23 +18,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * The log levels used by internal logging.
- */
+/// The log levels used by internal logging.
 typedef NS_ENUM(NSInteger, GULLoggerLevel) {
-  /** Error level, matches ASL_LEVEL_ERR. */
-  GULLoggerLevelError = 3,
-  /** Warning level, matches ASL_LEVEL_WARNING. */
-  GULLoggerLevelWarning = 4,
-  /** Notice level, matches ASL_LEVEL_NOTICE. */
-  GULLoggerLevelNotice = 5,
-  /** Info level, matches ASL_LEVEL_INFO. */
-  GULLoggerLevelInfo = 6,
-  /** Debug level, matches ASL_LEVEL_DEBUG. */
-  GULLoggerLevelDebug = 7,
-  /** Minimum log level. */
+  /// Error level, corresponding to `OS_LOG_TYPE_ERROR`.
+  GULLoggerLevelError = 3,  // For backwards compatibility, the enum value matches `ASL_LEVEL_ERR`.
+
+  /// Warning level, corresponding to `OS_LOG_TYPE_DEFAULT`.
+  ///
+  /// > Note: Since OSLog doesn't have a WARNING type, this is equivalent to `GULLoggerLevelNotice`.
+  GULLoggerLevelWarning = 4,  // For backwards compatibility, the value matches `ASL_LEVEL_WARNING`.
+
+  /// Notice level, corresponding to `OS_LOG_TYPE_DEFAULT`.
+  GULLoggerLevelNotice = 5,  // For backwards compatibility, the value matches `ASL_LEVEL_NOTICE`.
+
+  /// Info level, corresponding to `OS_LOG_TYPE_INFO`.
+  GULLoggerLevelInfo = 6,  // For backwards compatibility, the enum value matches `ASL_LEVEL_INFO`.
+
+  /// Debug level, corresponding to `OS_LOG_TYPE_DEBUG`.
+  GULLoggerLevelDebug = 7,  // For backwards compatibility, the value matches `ASL_LEVEL_DEBUG`.
+
+  /// The minimum (most severe) supported logging level.
   GULLoggerLevelMin = GULLoggerLevelError,
-  /** Maximum log level. */
+
+  /// The maximum (least severe) supported logging level.
   GULLoggerLevelMax = GULLoggerLevelDebug
 } NS_SWIFT_NAME(GoogleLoggerLevel);
 

--- a/GoogleUtilities/MethodSwizzler/GULSwizzler.m
+++ b/GoogleUtilities/MethodSwizzler/GULSwizzler.m
@@ -89,11 +89,12 @@ dispatch_queue_t GetGULSwizzlingQueue(void) {
         IMP testOriginal;
         [inv getReturnValue:&testOriginal];
         if (originalImpOfClass != testOriginal) {
-          GULLogWarning(kGULLogSubsystem, kGULLoggerSwizzler, NO,
-                        [NSString stringWithFormat:@"I-SWZ%06ld",
-                                                   (long)kGULSwizzlerMessageCodeMethodSwizzling000],
-                        @"Swizzling class: %@ SEL:%@ after it has been previously been swizzled.",
-                        NSStringFromClass(resolvedClass), NSStringFromSelector(selector));
+          GULOSLogWarning(
+              kGULLogSubsystem, kGULLoggerSwizzler, NO,
+              [NSString
+                  stringWithFormat:@"I-SWZ%06ld", (long)kGULSwizzlerMessageCodeMethodSwizzling000],
+              @"Swizzling class: %@ SEL:%@ after it has been previously been swizzled.",
+              NSStringFromClass(resolvedClass), NSStringFromSelector(selector));
         }
       }
     }

--- a/GoogleUtilities/MethodSwizzler/GULSwizzler.m
+++ b/GoogleUtilities/MethodSwizzler/GULSwizzler.m
@@ -89,7 +89,7 @@ dispatch_queue_t GetGULSwizzlingQueue(void) {
         IMP testOriginal;
         [inv getReturnValue:&testOriginal];
         if (originalImpOfClass != testOriginal) {
-          GULLogWarning(kGULLoggerSwizzler, NO,
+          GULLogWarning(kGULLogSubsystem, kGULLoggerSwizzler, NO,
                         [NSString stringWithFormat:@"I-SWZ%06ld",
                                                    (long)kGULSwizzlerMessageCodeMethodSwizzling000],
                         @"Swizzling class: %@ SEL:%@ after it has been previously been swizzled.",

--- a/GoogleUtilities/Network/GULNetwork.m
+++ b/GoogleUtilities/Network/GULNetwork.m
@@ -279,10 +279,11 @@ static NSString *const kGULNetworkLogTag = @"Google/Utilities/Network";
                                                                 messageCode:message:context:)] ||
       ![loggerDelegate respondsToSelector:@selector(GULNetwork_logWithLevel:
                                                                 messageCode:message:)]) {
-    GULLogError(kGULLogSubsystem, kGULLoggerNetwork, NO,
-                [NSString stringWithFormat:@"I-NET%06ld", (long)kGULNetworkMessageCodeNetwork002],
-                @"Cannot set the network logger delegate: delegate does not conform to the network "
-                 "logger protocol.");
+    GULOSLogError(
+        kGULLogSubsystem, kGULLoggerNetwork, NO,
+        [NSString stringWithFormat:@"I-NET%06ld", (long)kGULNetworkMessageCodeNetwork002],
+        @"Cannot set the network logger delegate: delegate does not conform to the network "
+         "logger protocol.");
     return;
   }
   _loggerDelegate = loggerDelegate;
@@ -329,9 +330,9 @@ static NSString *const kGULNetworkLogTag = @"Google/Utilities/Network";
       logLevel == kGULNetworkLogLevelWarning || logLevel == kGULNetworkLogLevelInfo) {
     NSString *formattedMessage = GULStringWithLogMessage(message, logLevel, contexts);
     NSLog(@"%@", formattedMessage);
-    GULLogBasic((GULLoggerLevel)logLevel, kGULLogSubsystem, kGULLoggerNetwork, NO,
-                [NSString stringWithFormat:@"I-NET%06ld", (long)messageCode], formattedMessage,
-                NULL);
+    GULOSLogBasic((GULLoggerLevel)logLevel, kGULLogSubsystem, kGULLoggerNetwork, NO,
+                  [NSString stringWithFormat:@"I-NET%06ld", (long)messageCode], formattedMessage,
+                  NULL);
   }
 }
 

--- a/GoogleUtilities/Network/GULNetwork.m
+++ b/GoogleUtilities/Network/GULNetwork.m
@@ -279,7 +279,7 @@ static NSString *const kGULNetworkLogTag = @"Google/Utilities/Network";
                                                                 messageCode:message:context:)] ||
       ![loggerDelegate respondsToSelector:@selector(GULNetwork_logWithLevel:
                                                                 messageCode:message:)]) {
-    GULLogError(kGULLoggerNetwork, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerNetwork, NO,
                 [NSString stringWithFormat:@"I-NET%06ld", (long)kGULNetworkMessageCodeNetwork002],
                 @"Cannot set the network logger delegate: delegate does not conform to the network "
                  "logger protocol.");
@@ -329,7 +329,7 @@ static NSString *const kGULNetworkLogTag = @"Google/Utilities/Network";
       logLevel == kGULNetworkLogLevelWarning || logLevel == kGULNetworkLogLevelInfo) {
     NSString *formattedMessage = GULStringWithLogMessage(message, logLevel, contexts);
     NSLog(@"%@", formattedMessage);
-    GULLogBasic((GULLoggerLevel)logLevel, kGULLoggerNetwork, NO,
+    GULLogBasic((GULLoggerLevel)logLevel, kGULLogSubsystem, kGULLoggerNetwork, NO,
                 [NSString stringWithFormat:@"I-NET%06ld", (long)messageCode], formattedMessage,
                 NULL);
   }

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -93,7 +93,7 @@
   if (fetcher != nil) {
     [fetcher addSystemCompletionHandler:systemCompletionHandler forSession:sessionID];
   } else {
-    GULLogError(kGULLoggerNetwork, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerNetwork, NO,
                 [NSString stringWithFormat:@"I-NET%06ld", (long)kGULNetworkMessageCodeNetwork003],
                 @"Failed to retrieve background session with ID %@ after app is relaunched.",
                 sessionID);

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -93,10 +93,10 @@
   if (fetcher != nil) {
     [fetcher addSystemCompletionHandler:systemCompletionHandler forSession:sessionID];
   } else {
-    GULLogError(kGULLogSubsystem, kGULLoggerNetwork, NO,
-                [NSString stringWithFormat:@"I-NET%06ld", (long)kGULNetworkMessageCodeNetwork003],
-                @"Failed to retrieve background session with ID %@ after app is relaunched.",
-                sessionID);
+    GULOSLogError(kGULLogSubsystem, kGULLoggerNetwork, NO,
+                  [NSString stringWithFormat:@"I-NET%06ld", (long)kGULNetworkMessageCodeNetwork003],
+                  @"Failed to retrieve background session with ID %@ after app is relaunched.",
+                  sessionID);
   }
 }
 

--- a/GoogleUtilities/Reachability/GULReachabilityChecker.m
+++ b/GoogleUtilities/Reachability/GULReachabilityChecker.m
@@ -64,7 +64,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
 - (void)setReachabilityApi:(const struct GULReachabilityApi *)reachabilityApi {
 #if !TARGET_OS_WATCH
   if (reachability_) {
-    GULLogError(kGULLoggerReachability, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
                 [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode000],
                 @"Cannot change reachability API while reachability is running. "
                 @"Call stop first.");
@@ -89,7 +89,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
 - (void)setReachabilityDelegate:(id<GULReachabilityDelegate>)reachabilityDelegate {
   if (reachabilityDelegate &&
       (![(NSObject *)reachabilityDelegate conformsToProtocol:@protocol(GULReachabilityDelegate)])) {
-    GULLogError(kGULLoggerReachability, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
                 [NSString stringWithFormat:@"I-NET%06ld", (long)kGULReachabilityMessageCode005],
                 @"Reachability delegate doesn't conform to Reachability protocol.");
     return;
@@ -102,7 +102,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
   self = [super init];
 
   if (!host || !host.length) {
-    GULLogError(kGULLoggerReachability, NO,
+    GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
                 [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode001],
                 @"Invalid host specified");
     return nil;
@@ -147,13 +147,13 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
       reachabilityApi_->releaseFn(reachability_);
       reachability_ = nil;
 
-      GULLogError(kGULLoggerReachability, NO,
+      GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
                   [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode002],
                   @"Failed to start reachability handle");
       return NO;
     }
   }
-  GULLogDebug(kGULLoggerReachability, NO,
+  GULLogDebug(kGULLogSubsystem, kGULLoggerReachability, NO,
               [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode003],
               @"Monitoring the network status");
   return YES;
@@ -214,7 +214,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
                                      : kGULReachabilityConnectedStatus;
     }
 
-    GULLogDebug(kGULLoggerReachability, NO,
+    GULLogDebug(kGULLogSubsystem, kGULLoggerReachability, NO,
                 [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode004],
                 @"Network status has changed. Code:%@, status:%@", @(status),
                 reachabilityStatusString);

--- a/GoogleUtilities/Reachability/GULReachabilityChecker.m
+++ b/GoogleUtilities/Reachability/GULReachabilityChecker.m
@@ -64,10 +64,10 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
 - (void)setReachabilityApi:(const struct GULReachabilityApi *)reachabilityApi {
 #if !TARGET_OS_WATCH
   if (reachability_) {
-    GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
-                [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode000],
-                @"Cannot change reachability API while reachability is running. "
-                @"Call stop first.");
+    GULOSLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
+                  [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode000],
+                  @"Cannot change reachability API while reachability is running. "
+                  @"Call stop first.");
     return;
   }
   reachabilityApi_ = reachabilityApi;
@@ -89,9 +89,9 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
 - (void)setReachabilityDelegate:(id<GULReachabilityDelegate>)reachabilityDelegate {
   if (reachabilityDelegate &&
       (![(NSObject *)reachabilityDelegate conformsToProtocol:@protocol(GULReachabilityDelegate)])) {
-    GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
-                [NSString stringWithFormat:@"I-NET%06ld", (long)kGULReachabilityMessageCode005],
-                @"Reachability delegate doesn't conform to Reachability protocol.");
+    GULOSLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
+                  [NSString stringWithFormat:@"I-NET%06ld", (long)kGULReachabilityMessageCode005],
+                  @"Reachability delegate doesn't conform to Reachability protocol.");
     return;
   }
   reachabilityDelegate_ = reachabilityDelegate;
@@ -102,9 +102,9 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
   self = [super init];
 
   if (!host || !host.length) {
-    GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
-                [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode001],
-                @"Invalid host specified");
+    GULOSLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
+                  [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode001],
+                  @"Invalid host specified");
     return nil;
   }
   if (self) {
@@ -147,15 +147,15 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
       reachabilityApi_->releaseFn(reachability_);
       reachability_ = nil;
 
-      GULLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
-                  [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode002],
-                  @"Failed to start reachability handle");
+      GULOSLogError(kGULLogSubsystem, kGULLoggerReachability, NO,
+                    [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode002],
+                    @"Failed to start reachability handle");
       return NO;
     }
   }
-  GULLogDebug(kGULLogSubsystem, kGULLoggerReachability, NO,
-              [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode003],
-              @"Monitoring the network status");
+  GULOSLogDebug(kGULLogSubsystem, kGULLoggerReachability, NO,
+                [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode003],
+                @"Monitoring the network status");
   return YES;
 #endif
 }
@@ -214,10 +214,10 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
                                      : kGULReachabilityConnectedStatus;
     }
 
-    GULLogDebug(kGULLogSubsystem, kGULLoggerReachability, NO,
-                [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode004],
-                @"Network status has changed. Code:%@, status:%@", @(status),
-                reachabilityStatusString);
+    GULOSLogDebug(kGULLogSubsystem, kGULLoggerReachability, NO,
+                  [NSString stringWithFormat:@"I-REA%06ld", (long)kGULReachabilityMessageCode004],
+                  @"Network status has changed. Code:%@, status:%@", @(status),
+                  reachabilityStatusString);
     reachabilityStatus_ = status;
     [reachabilityDelegate_ reachability:self statusChanged:reachabilityStatus_];
   }

--- a/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
@@ -63,46 +63,51 @@ static NSString *const kMessageCode = @"I-COR000001";
 
 - (void)testMessageCodeFormat {
   // Valid case.
-  XCTAssertNoThrow(GULLogError(@"my service", NO, @"I-APP000001", @"Message."));
+  XCTAssertNoThrow(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP000001", @"Message."));
 
   // An extra dash or missing dash should fail.
-  XCTAssertThrows(GULLogError(@"my service", NO, @"I-APP-000001", @"Message."));
-  XCTAssertThrows(GULLogError(@"my service", NO, @"IAPP000001", @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP-000001", @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"IAPP000001", @"Message."));
 
   // Wrong number of digits should fail.
-  XCTAssertThrows(GULLogError(@"my service", NO, @"I-APP00001", @"Message."));
-  XCTAssertThrows(GULLogError(@"my service", NO, @"I-APP0000001", @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP00001", @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP0000001", @"Message."));
 
   // Lowercase should fail.
-  XCTAssertThrows(GULLogError(@"my service", NO, @"I-app000001", @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-app000001", @"Message."));
 
 // nil or empty message code should fail.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-  XCTAssertThrows(GULLogError(@"my service", NO, nil, @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, nil, @"Message."));
 #pragma clang diagnostic pop
 
-  XCTAssertThrows(GULLogError(@"my service", NO, @"", @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"", @"Message."));
 
   // Android message code should fail.
-  XCTAssertThrows(GULLogError(@"my service", NO, @"A-APP000001", @"Message."));
+  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"A-APP000001", @"Message."));
 }
 
 - (void)testLoggerInterface {
-  XCTAssertNoThrow(GULLogError(@"my service", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(GULLogError(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+  XCTAssertNoThrow(GULLogError(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(
+      GULLogError(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
 
-  XCTAssertNoThrow(GULLogWarning(@"my service", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(GULLogWarning(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+  XCTAssertNoThrow(GULLogWarning(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(GULLogWarning(@"com.my.service", @"My/Category", NO, kMessageCode,
+                                 @"Configure %@.", @"blah"));
 
-  XCTAssertNoThrow(GULLogNotice(@"my service", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(GULLogNotice(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+  XCTAssertNoThrow(GULLogNotice(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(
+      GULLogNotice(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
 
-  XCTAssertNoThrow(GULLogInfo(@"my service", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(GULLogInfo(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+  XCTAssertNoThrow(GULLogInfo(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(
+      GULLogInfo(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
 
-  XCTAssertNoThrow(GULLogDebug(@"my service", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(GULLogDebug(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+  XCTAssertNoThrow(GULLogDebug(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(
+      GULLogDebug(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
 }
 
 // The GULLoggerLevel enum must match the ASL_LEVEL_* constants, but we manually redefine

--- a/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
@@ -16,21 +16,20 @@
 // The tests depend upon library methods only built with #ifdef DEBUG
 
 #import <OCMock/OCMock.h>
+#import <OSLog/OSLog.h>
 #import <XCTest/XCTest.h>
 
 #import "GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h"
 
 #import <asl.h>
 
-extern const char *kGULLoggerASLClientFacilityName;
-
 extern void GULResetLogger(void);
-
-extern aslclient getGULLoggerClient(void);
 
 extern dispatch_queue_t getGULClientQueue(void);
 
 extern BOOL getGULLoggerDebugMode(void);
+
+extern os_log_type_t GULLoggerLevelToOSLogType(GULLoggerLevel level);
 
 static NSString *const kMessageCode = @"I-COR000001";
 
@@ -45,7 +44,7 @@ static NSString *const kMessageCode = @"I-COR000001";
 @implementation GULLoggerTest
 
 + (void)setUp {
-  GULLoggerInitializeASL();
+  GULLoggerInitialize();
 }
 
 - (void)setUp {
@@ -115,6 +114,16 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertEqual(GULLoggerLevelNotice, ASL_LEVEL_NOTICE);
   XCTAssertEqual(GULLoggerLevelInfo, ASL_LEVEL_INFO);
   XCTAssertEqual(GULLoggerLevelDebug, ASL_LEVEL_DEBUG);
+}
+
+- (void)testGULLoggerLevelToOSLogType {
+  XCTAssertEqual(GULLoggerLevelToOSLogType(GULLoggerLevelError), OS_LOG_TYPE_ERROR);
+  // OSLog doesn't have a WARNING level so it is remapped to DEFAULT (Notice).
+  XCTAssertEqual(GULLoggerLevelToOSLogType(GULLoggerLevelWarning),
+                 GULLoggerLevelToOSLogType(GULLoggerLevelNotice));
+  XCTAssertEqual(GULLoggerLevelToOSLogType(GULLoggerLevelNotice), OS_LOG_TYPE_DEFAULT);
+  XCTAssertEqual(GULLoggerLevelToOSLogType(GULLoggerLevelInfo), OS_LOG_TYPE_INFO);
+  XCTAssertEqual(GULLoggerLevelToOSLogType(GULLoggerLevelDebug), OS_LOG_TYPE_DEBUG);
 }
 
 - (void)testGULGetLoggerLevel {

--- a/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Tests/Unit/Logger/GULLoggerTest.m
@@ -63,51 +63,34 @@ static NSString *const kMessageCode = @"I-COR000001";
 
 - (void)testMessageCodeFormat {
   // Valid case.
-  XCTAssertNoThrow(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP000001", @"Message."));
+  XCTAssertNoThrow(
+      GULOSLogError(@"com.my.service", @"My/Category", NO, @"I-APP000001", @"Message."));
 
   // An extra dash or missing dash should fail.
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP-000001", @"Message."));
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"IAPP000001", @"Message."));
+  XCTAssertThrows(
+      GULOSLogError(@"com.my.service", @"My/Category", NO, @"I-APP-000001", @"Message."));
+  XCTAssertThrows(GULOSLogError(@"com.my.service", @"My/Category", NO, @"IAPP000001", @"Message."));
 
   // Wrong number of digits should fail.
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP00001", @"Message."));
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-APP0000001", @"Message."));
+  XCTAssertThrows(GULOSLogError(@"com.my.service", @"My/Category", NO, @"I-APP00001", @"Message."));
+  XCTAssertThrows(
+      GULOSLogError(@"com.my.service", @"My/Category", NO, @"I-APP0000001", @"Message."));
 
   // Lowercase should fail.
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"I-app000001", @"Message."));
+  XCTAssertThrows(
+      GULOSLogError(@"com.my.service", @"My/Category", NO, @"I-app000001", @"Message."));
 
 // nil or empty message code should fail.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, nil, @"Message."));
+  XCTAssertThrows(GULOSLogError(@"com.my.service", @"My/Category", NO, nil, @"Message."));
 #pragma clang diagnostic pop
 
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"", @"Message."));
+  XCTAssertThrows(GULOSLogError(@"com.my.service", @"My/Category", NO, @"", @"Message."));
 
   // Android message code should fail.
-  XCTAssertThrows(GULLogError(@"com.my.service", @"My/Category", NO, @"A-APP000001", @"Message."));
-}
-
-- (void)testLoggerInterface {
-  XCTAssertNoThrow(GULLogError(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(
-      GULLogError(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
-
-  XCTAssertNoThrow(GULLogWarning(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(GULLogWarning(@"com.my.service", @"My/Category", NO, kMessageCode,
-                                 @"Configure %@.", @"blah"));
-
-  XCTAssertNoThrow(GULLogNotice(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(
-      GULLogNotice(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
-
-  XCTAssertNoThrow(GULLogInfo(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(
-      GULLogInfo(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
-
-  XCTAssertNoThrow(GULLogDebug(@"com.my.service", @"My/Category", NO, kMessageCode, @"Message."));
-  XCTAssertNoThrow(
-      GULLogDebug(@"com.my.service", @"My/Category", NO, kMessageCode, @"Configure %@.", @"blah"));
+  XCTAssertThrows(
+      GULOSLogError(@"com.my.service", @"My/Category", NO, @"A-APP000001", @"Message."));
 }
 
 // The GULLoggerLevel enum must match the ASL_LEVEL_* constants, but we manually redefine
@@ -156,6 +139,65 @@ static NSString *const kMessageCode = @"I-COR000001";
   // The default logger level is GULLoggerLevelNotice.
   XCTAssertEqual(loggerLevel, GULLoggerLevelNotice);
 }
+
+#pragma mark - Deprecated Functions
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+- (void)testDeprecatedInitializeASL {
+  XCTAssertNoThrow(GULLoggerInitializeASL());
+}
+
+- (void)testDeprecatedEnableSTDERR {
+  XCTAssertNoThrow(GULLoggerEnableSTDERR());
+}
+
+- (void)testDeprecatedMessageCodeFormat {
+  // Valid case.
+  XCTAssertNoThrow(GULLogError(@"my service", NO, @"I-APP000001", @"Message."));
+
+  // An extra dash or missing dash should fail.
+  XCTAssertThrows(GULLogError(@"my service", NO, @"I-APP-000001", @"Message."));
+  XCTAssertThrows(GULLogError(@"my service", NO, @"IAPP000001", @"Message."));
+
+  // Wrong number of digits should fail.
+  XCTAssertThrows(GULLogError(@"my service", NO, @"I-APP00001", @"Message."));
+  XCTAssertThrows(GULLogError(@"my service", NO, @"I-APP0000001", @"Message."));
+
+  // Lowercase should fail.
+  XCTAssertThrows(GULLogError(@"my service", NO, @"I-app000001", @"Message."));
+
+  // nil or empty message code should fail.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  XCTAssertThrows(GULLogError(@"my service", NO, nil, @"Message."));
+#pragma clang diagnostic pop
+
+  XCTAssertThrows(GULLogError(@"my service", NO, @"", @"Message."));
+
+  // Android message code should fail.
+  XCTAssertThrows(GULLogError(@"my service", NO, @"A-APP000001", @"Message."));
+}
+
+- (void)testDeprecatedLoggerInterface {
+  XCTAssertNoThrow(GULLogError(@"my service", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(GULLogError(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+
+  XCTAssertNoThrow(GULLogWarning(@"my service", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(GULLogWarning(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+
+  XCTAssertNoThrow(GULLogNotice(@"my service", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(GULLogNotice(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+
+  XCTAssertNoThrow(GULLogInfo(@"my service", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(GULLogInfo(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+
+  XCTAssertNoThrow(GULLogDebug(@"my service", NO, kMessageCode, @"Message."));
+  XCTAssertNoThrow(GULLogDebug(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
+}
+
+#pragma clang diagnostic pop
 
 @end
 #endif

--- a/GoogleUtilities/UserDefaults/GULUserDefaults.m
+++ b/GoogleUtilities/UserDefaults/GULUserDefaults.m
@@ -87,7 +87,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 - (nullable id)objectForKey:(NSString *)defaultName {
   NSString *key = [defaultName copy];
   if (![key isKindOfClass:[NSString class]] || !key.length) {
-    GULLogWarning(@"<GoogleUtilities>", NO,
+    GULLogWarning(kGULLogSubsystem, @"<GoogleUtilities>", NO,
                   [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidKeyGet],
                   @"Cannot get object for invalid user default key.");
     return nil;
@@ -98,7 +98,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 - (void)setObject:(nullable id)value forKey:(NSString *)defaultName {
   NSString *key = [defaultName copy];
   if (![key isKindOfClass:[NSString class]] || !key.length) {
-    GULLogWarning(kGULLogUserDefaultsService, NO,
+    GULLogWarning(kGULLogSubsystem, kGULLogUserDefaultsService, NO,
                   [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidKeySet],
                   @"Cannot set object for invalid user default key.");
     return;
@@ -113,7 +113,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
       [value isKindOfClass:[NSArray class]] || [value isKindOfClass:[NSDictionary class]] ||
       [value isKindOfClass:[NSDate class]] || [value isKindOfClass:[NSData class]];
   if (!isAcceptableValue) {
-    GULLogWarning(kGULLogUserDefaultsService, NO,
+    GULLogWarning(kGULLogSubsystem, kGULLogUserDefaultsService, NO,
                   [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidObjectSet],
                   @"Cannot set invalid object to user defaults. Must be a string, number, array, "
                   @"dictionary, date, or data. Value: %@",
@@ -185,7 +185,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 
 - (void)synchronize {
   if (!CFPreferencesAppSynchronize(_appNameRef)) {
-    GULLogError(kGULLogUserDefaultsService, NO,
+    GULLogError(kGULLogSubsystem, kGULLogUserDefaultsService, NO,
                 [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeSynchronizeFailed],
                 @"Cannot synchronize user defaults to disk");
   }

--- a/GoogleUtilities/UserDefaults/GULUserDefaults.m
+++ b/GoogleUtilities/UserDefaults/GULUserDefaults.m
@@ -87,9 +87,9 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 - (nullable id)objectForKey:(NSString *)defaultName {
   NSString *key = [defaultName copy];
   if (![key isKindOfClass:[NSString class]] || !key.length) {
-    GULLogWarning(kGULLogSubsystem, @"<GoogleUtilities>", NO,
-                  [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidKeyGet],
-                  @"Cannot get object for invalid user default key.");
+    GULOSLogWarning(kGULLogSubsystem, @"<GoogleUtilities>", NO,
+                    [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidKeyGet],
+                    @"Cannot get object for invalid user default key.");
     return nil;
   }
   return (__bridge_transfer id)CFPreferencesCopyAppValue((__bridge CFStringRef)key, _appNameRef);
@@ -98,9 +98,9 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 - (void)setObject:(nullable id)value forKey:(NSString *)defaultName {
   NSString *key = [defaultName copy];
   if (![key isKindOfClass:[NSString class]] || !key.length) {
-    GULLogWarning(kGULLogSubsystem, kGULLogUserDefaultsService, NO,
-                  [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidKeySet],
-                  @"Cannot set object for invalid user default key.");
+    GULOSLogWarning(kGULLogSubsystem, kGULLogUserDefaultsService, NO,
+                    [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidKeySet],
+                    @"Cannot set object for invalid user default key.");
     return;
   }
   if (!value) {
@@ -113,11 +113,12 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
       [value isKindOfClass:[NSArray class]] || [value isKindOfClass:[NSDictionary class]] ||
       [value isKindOfClass:[NSDate class]] || [value isKindOfClass:[NSData class]];
   if (!isAcceptableValue) {
-    GULLogWarning(kGULLogSubsystem, kGULLogUserDefaultsService, NO,
-                  [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidObjectSet],
-                  @"Cannot set invalid object to user defaults. Must be a string, number, array, "
-                  @"dictionary, date, or data. Value: %@",
-                  value);
+    GULOSLogWarning(
+        kGULLogSubsystem, kGULLogUserDefaultsService, NO,
+        [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeInvalidObjectSet],
+        @"Cannot set invalid object to user defaults. Must be a string, number, array, "
+        @"dictionary, date, or data. Value: %@",
+        value);
     return;
   }
 
@@ -185,9 +186,10 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 
 - (void)synchronize {
   if (!CFPreferencesAppSynchronize(_appNameRef)) {
-    GULLogError(kGULLogSubsystem, kGULLogUserDefaultsService, NO,
-                [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeSynchronizeFailed],
-                @"Cannot synchronize user defaults to disk");
+    GULOSLogError(
+        kGULLogSubsystem, kGULLogUserDefaultsService, NO,
+        [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeSynchronizeFailed],
+        @"Cannot synchronize user defaults to disk");
   }
 }
 


### PR DESCRIPTION
Migrated from `ASL` to `OSLog` in `GULLogger` but retained the existing API (now deprecated) for backwards compatibility.