### PR TITLE
[v8] Replace CFPreferences with NSUserDefaults

### DIFF
--- a/GoogleUtilities/Tests/Unit/UserDefaults/GULUserDefaultsTests.m
+++ b/GoogleUtilities/Tests/Unit/UserDefaults/GULUserDefaultsTests.m
@@ -363,29 +363,6 @@ static const NSTimeInterval kGULTestCaseTimeoutInterval = 10;
   [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:appDomain];
 }
 
-- (void)testUserDefaultNotifications {
-  // Test to ensure no notifications are sent with our implementation.
-  void (^callBlock)(NSNotification *) = ^(NSNotification *_Nonnull notification) {
-    XCTFail(@"A notification must not be sent for GULUserDefaults!");
-  };
-
-  id observer =
-      [[NSNotificationCenter defaultCenter] addObserverForName:NSUserDefaultsDidChangeNotification
-                                                        object:nil
-                                                         queue:nil
-                                                    usingBlock:callBlock];
-  NSString *suiteName = @"test_suite_notification";
-  GULUserDefaults *newUserDefaults = [[GULUserDefaults alloc] initWithSuiteName:suiteName];
-  [newUserDefaults setObject:@"134" forKey:@"test-another"];
-  XCTAssertEqualObjects([newUserDefaults objectForKey:@"test-another"], @"134");
-  [newUserDefaults setObject:nil forKey:@"test-another"];
-  XCTAssertNil([newUserDefaults objectForKey:@"test-another"]);
-  [[NSNotificationCenter defaultCenter] removeObserver:observer];
-
-  // Remove the underlying reference file.
-  [self removePreferenceFileWithSuiteName:suiteName];
-}
-
 - (void)testSynchronizeToDisk {
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST || SWIFT_PACKAGE
   // `NSFileManager` has trouble reading the files in `~/Library` even though the

--- a/GoogleUtilities/Tests/Unit/UserDefaults/GULUserDefaultsTests.m
+++ b/GoogleUtilities/Tests/Unit/UserDefaults/GULUserDefaultsTests.m
@@ -380,7 +380,6 @@ static const NSTimeInterval kGULTestCaseTimeoutInterval = 10;
   XCTAssertEqualObjects([newUserDefaults objectForKey:@"test-another"], @"134");
   [newUserDefaults setObject:nil forKey:@"test-another"];
   XCTAssertNil([newUserDefaults objectForKey:@"test-another"]);
-  [newUserDefaults synchronize];
   [[NSNotificationCenter defaultCenter] removeObserver:observer];
 
   // Remove the underlying reference file.
@@ -406,14 +405,12 @@ static const NSTimeInterval kGULTestCaseTimeoutInterval = 10;
 
   GULUserDefaults *newUserDefaults = [[GULUserDefaults alloc] initWithSuiteName:suiteName];
   [newUserDefaults setObject:@"134" forKey:@"test-another"];
-  [newUserDefaults synchronize];
 
   XCTAssertTrue([fileManager fileExistsAtPath:filePath],
                 @"The user defaults file was not synchronized to disk.");
 
   // Now get the file directly from disk.
   XCTAssertTrue([fileManager fileExistsAtPath:filePath]);
-  [newUserDefaults synchronize];
 
   [self removePreferenceFileWithSuiteName:suiteName];
 #endif  // TARGET_OS_OSX || TARGET_OS_MACCATALYST || SWIFT_PACKAGE

--- a/GoogleUtilities/UserDefaults/GULUserDefaults.m
+++ b/GoogleUtilities/UserDefaults/GULUserDefaults.m
@@ -56,8 +56,8 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
   NSString *name = [suiteName copy];
 
   if (self) {
-    _userDefaults = 
-        name.length ? [[NSUserDefaults alloc] initWithSuiteName:name] : [NSUserDefaults standardUserDefaults];
+    _userDefaults = name.length ? [[NSUserDefaults alloc] initWithSuiteName:name]
+                                : [NSUserDefaults standardUserDefaults];
   }
 
   return self;
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
                   @"Cannot get object for invalid user default key.");
     return nil;
   }
-  
+
   return [self.userDefaults objectForKey:key];
 }
 

--- a/GoogleUtilities/UserDefaults/GULUserDefaults.m
+++ b/GoogleUtilities/UserDefaults/GULUserDefaults.m
@@ -31,18 +31,11 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 
 @interface GULUserDefaults ()
 
-/// Equivalent to the suite name for NSUserDefaults.
-@property(readonly) CFStringRef appNameRef;
-
-@property(atomic) BOOL isPreferenceFileExcluded;
+@property(nonatomic, readonly) NSUserDefaults *userDefaults;
 
 @end
 
-@implementation GULUserDefaults {
-  // The application name is the same with the suite name of the NSUserDefaults, and it is used for
-  // preferences.
-  CFStringRef _appNameRef;
-}
+@implementation GULUserDefaults
 
 + (GULUserDefaults *)standardUserDefaults {
   static GULUserDefaults *standardUserDefaults;
@@ -63,25 +56,11 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
   NSString *name = [suiteName copy];
 
   if (self) {
-    // `kCFPreferencesCurrentApplication` maps to the same defaults database as
-    // `[NSUserDefaults standardUserDefaults]`.
-    _appNameRef =
-        name.length ? (__bridge_retained CFStringRef)name : kCFPreferencesCurrentApplication;
+    _userDefaults = 
+        name.length ? [[NSUserDefaults alloc] initWithSuiteName:name] : [NSUserDefaults standardUserDefaults];
   }
 
   return self;
-}
-
-- (void)dealloc {
-  // If we're using a custom `_appNameRef` it needs to be released. If it's a constant, it shouldn't
-  // need to be released since we don't own it.
-  if (CFStringCompare(_appNameRef, kCFPreferencesCurrentApplication, 0) != kCFCompareEqualTo) {
-    CFRelease(_appNameRef);
-  }
-
-  [NSObject cancelPreviousPerformRequestsWithTarget:self
-                                           selector:@selector(synchronize)
-                                             object:nil];
 }
 
 - (nullable id)objectForKey:(NSString *)defaultName {
@@ -92,7 +71,8 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
                   @"Cannot get object for invalid user default key.");
     return nil;
   }
-  return (__bridge_transfer id)CFPreferencesCopyAppValue((__bridge CFStringRef)key, _appNameRef);
+  
+  return [self.userDefaults objectForKey:key];
 }
 
 - (void)setObject:(nullable id)value forKey:(NSString *)defaultName {
@@ -104,8 +84,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
     return;
   }
   if (!value) {
-    CFPreferencesSetAppValue((__bridge CFStringRef)key, NULL, _appNameRef);
-    [self synchronize];
+    [self.userDefaults removeObjectForKey:key];
     return;
   }
   BOOL isAcceptableValue =
@@ -121,8 +100,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
     return;
   }
 
-  CFPreferencesSetAppValue((__bridge CFStringRef)key, (__bridge CFStringRef)value, _appNameRef);
-  [self synchronize];
+  [self.userDefaults setObject:value forKey:key];
 }
 
 - (void)removeObjectForKey:(NSString *)key {
@@ -179,16 +157,6 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 
 - (void)setBool:(BOOL)boolValue forKey:(NSString *)defaultName {
   [self setObject:@(boolValue) forKey:defaultName];
-}
-
-#pragma mark - Save data
-
-- (void)synchronize {
-  if (!CFPreferencesAppSynchronize(_appNameRef)) {
-    GULLogError(kGULLogUserDefaultsService, NO,
-                [NSString stringWithFormat:kGULLogFormat, (long)GULUDMessageCodeSynchronizeFailed],
-                @"Cannot synchronize user defaults to disk");
-  }
 }
 
 @end

--- a/GoogleUtilities/UserDefaults/Public/GoogleUtilities/GULUserDefaults.h
+++ b/GoogleUtilities/UserDefaults/Public/GoogleUtilities/GULUserDefaults.h
@@ -100,11 +100,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Equivalent to -[... setObject:nil forKey:defaultName]
 - (void)removeObjectForKey:(NSString *)defaultName;
 
-#pragma mark - Save data
-
-/// Blocks the calling thread until all in-progress set operations have completed.
-- (void)synchronize;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
With the min. OS version matrix moving to iOS 12.0+, the iOS 11.0 (https://github.com/firebase/firebase-ios-sdk/pull/1812#issue-359943861) bug where the user-defaults-spawned notification causes an app crash is no longer relevant. The bug was fixed but there likely were unfixed versions of iOS 11.0 where the CFPreferences implementation was still needed.