### PR TITLE
[v8] Replaced deprecated network info API

### DIFF
--- a/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
+++ b/GoogleUtilities/Environment/NetworkInfo/GULNetworkInfo.m
@@ -70,13 +70,11 @@
 + (NSString *)getNetworkRadioType {
 #ifdef TARGET_HAS_MOBILE_CONNECTIVITY
   CTTelephonyNetworkInfo *networkInfo = [GULNetworkInfo getNetworkInfo];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  return networkInfo.currentRadioAccessTechnology;
-#pragma clang diagnostic pop
-#else
-  return @"";
+  if (networkInfo.serviceCurrentRadioAccessTechnology.count) {
+    return networkInfo.serviceCurrentRadioAccessTechnology.allValues[0] ?: @"";
+  }
 #endif
+  return @"";
 }
 
 @end


### PR DESCRIPTION
Taking same approach to what is done in GDT: 

https://github.com/google/GoogleDataTransport/blob/e6d2576c9d1910bf92739c907aa544e1cdb29982/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m#L133-L141