### PR TITLE
[v8] Update privacy manifest for v8

### DIFF
--- a/GoogleUtilities/Environment/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Environment/Resources/PrivacyInfo.xcprivacy
@@ -17,7 +17,6 @@
                         <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
                         <key>NSPrivacyAccessedAPITypeReasons</key>
                         <array>
-                                <string>1C8F.1</string>
                                 <string>C56D.1</string>
                         </array>
                 </dict>

--- a/GoogleUtilities/Privacy/Resources/PrivacyInfo.xcprivacy
+++ b/GoogleUtilities/Privacy/Resources/PrivacyInfo.xcprivacy
@@ -25,7 +25,6 @@
                         <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
                         <key>NSPrivacyAccessedAPITypeReasons</key>
                         <array>
-                                <string>1C8F.1</string>
                                 <string>C56D.1</string>
                         </array>
                 </dict>


### PR DESCRIPTION
The need for the [1C8F.1 reason](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#:~:text=1C8F.1,same%20App%20Group.) was removed with the removal of the `GULHeartbeatDateStorage` class in v8 (#164). 