### PR TITLE
[NFC] Remove unneccessary visionOS #if logic

### DIFF
--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -698,9 +698,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
 
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 
-// TODO(Xcode 15): When Xcode 15 is the minimum supported Xcode version,
-// it will be unnecessary to check if `TARGET_OS_VISION` is defined.
-#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#if TARGET_OS_IOS
 
 - (BOOL)application:(GULApplication *)application
               openURL:(NSURL *)url
@@ -733,7 +731,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   return returnedValue;
 }
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#endif  // TARGET_OS_IOS
 
 #pragma mark - [Donor Methods] Network overridden handler methods
 

--- a/GoogleUtilities/AppDelegateSwizzler/Public/GoogleUtilities/GULApplication.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Public/GoogleUtilities/GULApplication.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 
 #import <UIKit/UIKit.h>
 

--- a/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
@@ -167,7 +167,7 @@ static BOOL HasEmbeddedMobileProvision(void) {
     model = @"watchOS Simulator";
 #elif TARGET_OS_TV
     model = @"tvOS Simulator";
-#elif defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#elif TARGET_OS_VISION
     model = @"visionOS Simulator";
 #elif TARGET_OS_IOS
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
@@ -195,8 +195,7 @@ static BOOL HasEmbeddedMobileProvision(void) {
 + (NSString *)systemVersion {
 #if TARGET_OS_IOS
   return [UIDevice currentDevice].systemVersion;
-#elif TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH || \
-    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#elif TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH || TARGET_OS_VISION
   // Assemble the systemVersion, excluding the patch version if it's 0.
   NSOperatingSystemVersion osVersion = [NSProcessInfo processInfo].operatingSystemVersion;
   NSMutableString *versionString = [[NSMutableString alloc]
@@ -225,7 +224,7 @@ static BOOL HasEmbeddedMobileProvision(void) {
   // `true`, which means the condition list is order-sensitive.
 #if TARGET_OS_MACCATALYST
   applePlatform = @"maccatalyst";
-#elif TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#elif TARGET_OS_IOS && !TARGET_OS_VISION
   if (@available(iOS 14.0, *)) {
     // Early iOS 14 betas do not include isiOSAppOnMac (#6969)
     applePlatform = ([[NSProcessInfo processInfo] respondsToSelector:@selector(isiOSAppOnMac)] &&
@@ -241,7 +240,7 @@ static BOOL HasEmbeddedMobileProvision(void) {
   applePlatform = @"macos";
 #elif TARGET_OS_WATCH
   applePlatform = @"watchos";
-#elif defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#elif TARGET_OS_VISION
   applePlatform = @"visionos";
 #endif  // TARGET_OS_MACCATALYST
 

--- a/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
@@ -224,7 +224,7 @@ static BOOL HasEmbeddedMobileProvision(void) {
   // `true`, which means the condition list is order-sensitive.
 #if TARGET_OS_MACCATALYST
   applePlatform = @"maccatalyst";
-#elif TARGET_OS_IOS && !TARGET_OS_VISION
+#elif TARGET_OS_IOS
   if (@available(iOS 14.0, *)) {
     // Early iOS 14 betas do not include isiOSAppOnMac (#6969)
     applePlatform = ([[NSProcessInfo processInfo] respondsToSelector:@selector(isiOSAppOnMac)] &&

--- a/GoogleUtilities/Reachability/GULReachabilityChecker.m
+++ b/GoogleUtilities/Reachability/GULReachabilityChecker.m
@@ -180,7 +180,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
     // Reachable flag is set. Check further flags.
     if (!(flags & kSCNetworkReachabilityFlagsConnectionRequired)) {
 // Connection required flag is not set, so we have connectivity.
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
       status = (flags & kSCNetworkReachabilityFlagsIsWWAN) ? kGULReachabilityViaCellular
                                                            : kGULReachabilityViaWifi;
 #elif TARGET_OS_OSX
@@ -191,7 +191,7 @@ static NSString *const kGULReachabilityDisconnectedStatus = @"Disconnected";
                !(flags & kSCNetworkReachabilityFlagsInterventionRequired)) {
 // If the connection on demand or connection on traffic flag is set, and user intervention
 // is not required, we have connectivity.
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
       status = (flags & kSCNetworkReachabilityFlagsIsWWAN) ? kGULReachabilityViaCellular
                                                            : kGULReachabilityViaWifi;
 #elif TARGET_OS_OSX

--- a/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
@@ -96,7 +96,7 @@
   // and `TARGET_OS_IOS` are `true` when building a macCatalyst app.
 #if TARGET_OS_MACCATALYST
   NSString *expectedPlatform = @"maccatalyst";
-#elif TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#elif TARGET_OS_IOS && !TARGET_OS_VISION
   NSString *expectedPlatform = @"ios";
 #elif TARGET_OS_TV
   NSString *expectedPlatform = @"tvos";
@@ -106,9 +106,9 @@
   NSString *expectedPlatform = @"watchos";
 #endif  // TARGET_OS_MACCATALYST
 
-#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#if TARGET_OS_VISION
   NSString *expectedPlatform = @"visionos";
-#endif  // defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#endif  // TARGET_OS_VISION
 
   XCTAssertEqualObjects([GULAppEnvironmentUtil applePlatform], expectedPlatform);
 }
@@ -118,7 +118,7 @@
   // `true`.
 #if TARGET_OS_MACCATALYST
   NSString *expectedPlatform = @"maccatalyst";
-#elif TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#elif TARGET_OS_IOS && !TARGET_OS_VISION
   NSString *expectedPlatform = @"ios";
 
   if ([[UIDevice currentDevice].model.lowercaseString containsString:@"ipad"] ||
@@ -139,9 +139,9 @@
   NSString *expectedPlatform = @"watchos";
 #endif  // TARGET_OS_WATCH
 
-#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#if TARGET_OS_VISION
   NSString *expectedPlatform = @"visionos";
-#endif  // defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#endif  // TARGET_OS_VISION
 
   XCTAssertEqualObjects([GULAppEnvironmentUtil appleDevicePlatform], expectedPlatform);
 }

--- a/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULAppEnvironmentUtilTest.m
@@ -96,7 +96,7 @@
   // and `TARGET_OS_IOS` are `true` when building a macCatalyst app.
 #if TARGET_OS_MACCATALYST
   NSString *expectedPlatform = @"maccatalyst";
-#elif TARGET_OS_IOS && !TARGET_OS_VISION
+#elif TARGET_OS_IOS
   NSString *expectedPlatform = @"ios";
 #elif TARGET_OS_TV
   NSString *expectedPlatform = @"tvos";
@@ -118,7 +118,7 @@
   // `true`.
 #if TARGET_OS_MACCATALYST
   NSString *expectedPlatform = @"maccatalyst";
-#elif TARGET_OS_IOS && !TARGET_OS_VISION
+#elif TARGET_OS_IOS
   NSString *expectedPlatform = @"ios";
 
   if ([[UIDevice currentDevice].model.lowercaseString containsString:@"ipad"] ||


### PR DESCRIPTION
1. Remove `defined(TARGET_OS_VISION)`
2. `TARGET_OS_IOS && !TARGET_OS_VISION` can be simplified to `TARGET_OS_IOS`
   -  See https://github.com/firebase/firebase-ios-sdk/pull/13184#issue-2373645638