### PR TITLE
Remove `Promises` dependency in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,7 +59,6 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/google/promises.git", "1.2.8" ..< "3.0.0"),
     // TODO: restore OCMock when https://github.com/erikdoe/ocmock/pull/537
     // gets merged to fix Xcode 15.3 builds.
     .package(


### PR DESCRIPTION
The dependency on https://github.com/google/promises is no longer needed.