### PR TITLE
Add OSLog to podspec

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -58,6 +58,9 @@ other Google CocoaPods. They're not intended for direct public usage.
     ls.public_header_files = 'GoogleUtilities/Logger/Public/GoogleUtilities/*.h'
     ls.dependency 'GoogleUtilities/Environment'
     ls.dependency 'GoogleUtilities/Privacy'
+    ls.frameworks = [
+      'OSLog'
+    ]
   end
 
 


### PR DESCRIPTION
I think the modern linkers may find these without declaration, but just in case, and for consistency

Note, that we don't declare any framework deps in Package.swift