### PR TITLE
Revert "Add OSLog to podspec (#201)"

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -58,9 +58,6 @@ other Google CocoaPods. They're not intended for direct public usage.
     ls.public_header_files = 'GoogleUtilities/Logger/Public/GoogleUtilities/*.h'
     ls.dependency 'GoogleUtilities/Environment'
     ls.dependency 'GoogleUtilities/Privacy'
-    ls.frameworks = [
-      'OSLog'
-    ]
   end
 
 


### PR DESCRIPTION
This reverts commit 493b5a0d33a5d76819034c3396a5a50140af4b06. No longer needed with https://github.com/google/GoogleUtilities/pull/203.