### PR TITLE
Remove leftover `#undef GUL_LOGGING_FUNCTION`

### DIFF
--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -172,8 +172,6 @@ void GULOSLogBasic(GULLoggerLevel level,
   });
 }
 
-#undef GUL_LOGGING_FUNCTION
-
 /**
  * Generates the logging functions using macros.
  *


### PR DESCRIPTION
Removed an extraneous `#undef GUL_LOGGING_FUNCTION` (leftover from the macro for the deprecated functions -- already deleted).