### PR TITLE
Set default logger level to `GULLoggerLevelNotice`

### DIFF
--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -45,6 +45,7 @@ static NSRegularExpression *sMessageCodeRegex;
 
 void GULLoggerInitialize(void) {
   dispatch_once(&sGULLoggerOnceToken, ^{
+    sGULLoggerMaximumLevel = GULLoggerLevelNotice;
     sGULClientQueue = dispatch_queue_create("GULLoggingClientQueue", DISPATCH_QUEUE_SERIAL);
     dispatch_set_target_queue(sGULClientQueue,
                               dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0));

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -72,7 +72,7 @@ GULLoggerLevel GULGetLoggerLevel(void) {
 
 __attribute__((no_sanitize("thread"))) void GULSetLoggerLevel(GULLoggerLevel loggerLevel) {
   if (loggerLevel < GULLoggerLevelMin || loggerLevel > GULLoggerLevelMax) {
-    GULOSLogError(kGULLogSubsystem, kGULLoggerLogger, NO, @"I-COR000023",
+    GULOSLogError(kGULLogSubsystem, kGULLoggerLogger, YES, @"I-COR000023",
                   @"Invalid logger level, %ld", (long)loggerLevel);
     return;
   }


### PR DESCRIPTION
Setting a default logger level (`sGULLoggerMaximumLevel`) was erroneously removed in [#192](https://github.com/google/GoogleUtilities/pull/192/files#diff-87f09690a8bbc2864d7384f85b7a75f1326306f1c925317800731fffd96dd91eL66) and, prior to this PR, had a value of `0` instead of `GULLoggerLevelNotice` (`5`) resulting in no logging without `-FIRDebugEnabled`. This re-adds the deleted line in `GULLoggerInitialize()`.