### PR TITLE
Move SwiftFormat options to a config file

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,14 @@
+# Formatting Options - Mimic Google style
+--indent 2
+--maxwidth 100
+--wrapparameters afterfirst
+
+# Disabled Rules
+
+# Too many of our swift files have simplistic examples. While technically
+# it's correct to remove the unused argument labels, it makes our examples
+# look wrong.
+--disable unusedArguments
+
+# We prefer trailing braces.
+--disable wrapMultilineStatementBraces

--- a/GoogleUtilities/Tests/SwiftUnit/GULAppEnvironmentUtilTest.swift
+++ b/GoogleUtilities/Tests/SwiftUnit/GULAppEnvironmentUtilTest.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import XCTest
 @testable import GoogleUtilities
+import XCTest
 
 class GULAppEnvironmentUtilTest: XCTestCase {
   func testIsAppExtension() throws {


### PR DESCRIPTION
The code formatting script from https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/style.sh now expects the Swift formatting options to be in a `.swiftformat` file as of https://github.com/firebase/firebase-ios-sdk/pull/13423.