### PR TITLE
[Infra] Prefer `setup_check.sh` over manual config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: '3.10'
 
     - name: Cache Mint packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ${{ env.MINT_PATH }}
         key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,11 +32,7 @@ jobs:
       run: ./setup-scripts.sh
 
     - name: Setup check
-      run: |
-        brew update
-        brew install clang-format@19
-        brew install mint
-        mint bootstrap
+      run: scripts/setup_check.sh
 
     - name: Style
       run: scripts/style.sh test-only

--- a/GoogleUtilities/MethodSwizzler/Public/GoogleUtilities/GULOriginalIMPConvenienceMacros.h
+++ b/GoogleUtilities/MethodSwizzler/Public/GoogleUtilities/GULOriginalIMPConvenienceMacros.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param __originalIMP The original IMP.
  */
 #define GUL_INVOKE_ORIGINAL_IMP0(__receivingObject, __swizzledSEL, __returnType, __originalIMP) \
-  ((__returnType(*)(id, SEL))__originalIMP)(__receivingObject, __swizzledSEL)
+  ((__returnType (*)(id, SEL))__originalIMP)(__receivingObject, __swizzledSEL)
 
 /**
  *  Invokes original IMP when the original selector takes 1 argument.
@@ -44,10 +44,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param __originalIMP The original IMP.
  *  @param __arg1 The first argument.
  */
-#define GUL_INVOKE_ORIGINAL_IMP1(__receivingObject, __swizzledSEL, __returnType, __originalIMP,   \
-                                 __arg1)                                                          \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1)))__originalIMP)(__receivingObject, __swizzledSEL, \
-                                                                __arg1)
+#define GUL_INVOKE_ORIGINAL_IMP1(__receivingObject, __swizzledSEL, __returnType, __originalIMP,    \
+                                 __arg1)                                                           \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1)))__originalIMP)(__receivingObject, __swizzledSEL, \
+                                                                 __arg1)
 
 /**
  *  Invokes original IMP when the original selector takes 2 arguments.
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #define GUL_INVOKE_ORIGINAL_IMP2(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
                                  __arg1, __arg2)                                                \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2)))__originalIMP)(            \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2)))__originalIMP)(           \
       __receivingObject, __swizzledSEL, __arg1, __arg2)
 
 /**
@@ -75,11 +75,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param __arg2 The second argument.
  *  @param __arg3 The third argument.
  */
-#define GUL_INVOKE_ORIGINAL_IMP3(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
-                                 __arg1, __arg2, __arg3)                                         \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2),                             \
-                    __typeof__(__arg3)))__originalIMP)(__receivingObject, __swizzledSEL, __arg1, \
-                                                       __arg2, __arg3)
+#define GUL_INVOKE_ORIGINAL_IMP3(__receivingObject, __swizzledSEL, __returnType, __originalIMP,   \
+                                 __arg1, __arg2, __arg3)                                          \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2),                             \
+                     __typeof__(__arg3)))__originalIMP)(__receivingObject, __swizzledSEL, __arg1, \
+                                                        __arg2, __arg3)
 
 /**
  *  Invokes original IMP when the original selector takes 4 arguments.
@@ -93,11 +93,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param __arg3 The third argument.
  *  @param __arg4 The fourth argument.
  */
-#define GUL_INVOKE_ORIGINAL_IMP4(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
-                                 __arg1, __arg2, __arg3, __arg4)                                 \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),         \
-                    __typeof__(__arg4)))__originalIMP)(__receivingObject, __swizzledSEL, __arg1, \
-                                                       __arg2, __arg3, __arg4)
+#define GUL_INVOKE_ORIGINAL_IMP4(__receivingObject, __swizzledSEL, __returnType, __originalIMP,   \
+                                 __arg1, __arg2, __arg3, __arg4)                                  \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),         \
+                     __typeof__(__arg4)))__originalIMP)(__receivingObject, __swizzledSEL, __arg1, \
+                                                        __arg2, __arg3, __arg4)
 
 /**
  *  Invokes original IMP when the original selector takes 5 arguments.
@@ -114,8 +114,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #define GUL_INVOKE_ORIGINAL_IMP5(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
                                  __arg1, __arg2, __arg3, __arg4, __arg5)                        \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
-                    __typeof__(__arg4), __typeof__(__arg5)))__originalIMP)(                     \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),       \
+                     __typeof__(__arg4), __typeof__(__arg5)))__originalIMP)(                    \
       __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5)
 
 /**
@@ -132,10 +132,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param __arg5 The fifth argument.
  *  @param __arg6 The sixth argument.
  */
-#define GUL_INVOKE_ORIGINAL_IMP6(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
-                                 __arg1, __arg2, __arg3, __arg4, __arg5, __arg6)                \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
-                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6)))__originalIMP)( \
+#define GUL_INVOKE_ORIGINAL_IMP6(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
+                                 __arg1, __arg2, __arg3, __arg4, __arg5, __arg6)                 \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
+                     __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6)))__originalIMP)( \
       __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6)
 
 /**
@@ -155,9 +155,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #define GUL_INVOKE_ORIGINAL_IMP7(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
                                  __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7)        \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
-                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                 \
-                    __typeof__(__arg7)))__originalIMP)(                                         \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),       \
+                     __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                \
+                     __typeof__(__arg7)))__originalIMP)(                                        \
       __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7)
 
 /**
@@ -178,9 +178,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 #define GUL_INVOKE_ORIGINAL_IMP8(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
                                  __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8) \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),         \
-                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                  \
-                    __typeof__(__arg7), __typeof__(__arg8)))__originalIMP)(                      \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
+                     __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                 \
+                     __typeof__(__arg7), __typeof__(__arg8)))__originalIMP)(                     \
       __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7,  \
       __arg8)
 
@@ -204,9 +204,9 @@ NS_ASSUME_NONNULL_BEGIN
 #define GUL_INVOKE_ORIGINAL_IMP9(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
                                  __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8, \
                                  __arg9)                                                         \
-  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),         \
-                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                  \
-                    __typeof__(__arg7), __typeof__(__arg8), __typeof__(__arg9)))__originalIMP)(  \
+  ((__returnType (*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
+                     __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                 \
+                     __typeof__(__arg7), __typeof__(__arg8), __typeof__(__arg9)))__originalIMP)( \
       __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7,  \
       __arg8, __arg9)
 


### PR DESCRIPTION
This simplifies things by getting clang-format from the firebase-ios-sdk checkout during CI rather than from this repo.

Corresponding GoogleDataTransport PR: https://github.com/google/GoogleDataTransport/pull/157