### PR TITLE
Add a utility to detect App Clips and make a semantic check for background URL sessions

### DIFF
--- a/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/GULAppEnvironmentUtil.m
@@ -217,6 +217,25 @@ static BOOL HasEmbeddedMobileProvision(void) {
 #endif
 }
 
++ (BOOL)isAppClip {
+#if TARGET_OS_IOS
+  // Documented by <a
+  // href="https://developer.apple.com/documentation/bundleresources/information-property-list/nsappclip">Apple</a>
+  // App clips have an NSAppClip entry in the top level of their Info.plist.
+  NSDictionary *appClipEntry = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSAppClip"];
+  return appClipEntry != nil;
+#elif TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH || TARGET_OS_VISION
+  return NO;
+#endif
+}
+
++ (BOOL)supportsBackgroundURLSessionUploads {
+  // Neither app extensions nor App Clips support background uploads.
+  BOOL isExtension = self.isAppExtension;
+  BOOL isAppClip = self.isAppClip;
+  return !(isExtension || isAppClip);
+}
+
 + (NSString *)applePlatform {
   NSString *applePlatform = @"unknown";
 

--- a/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
+++ b/GoogleUtilities/Environment/Public/GoogleUtilities/GULAppEnvironmentUtil.h
@@ -46,6 +46,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Indicates whether it is running inside an extension or an app.
 + (BOOL)isAppExtension;
 
+/// Indicates whether it is running inside an app clip or a full app.
++ (BOOL)isAppClip;
+
+/// Indicates whether the current target supports background URL session uploads.
+/// App extensions and app clips do not support background URL sessions.
++ (BOOL)supportsBackgroundURLSessionUploads;
+
 /// @return An Apple platform. Possible values "ios", "tvos", "macos", "watchos", "maccatalyst", and
 /// "visionos".
 + (NSString *)applePlatform;


### PR DESCRIPTION
This adds two utility functions to `GULAppEnvironmentUtil.m`:

- `isAppClip`, which determines heuristically whether the current app is an App Clip. I do not think it's necessarily _required_ that app clips have this top level dictionary in their Info.plist, but in practice I would assume almost all do.
- `supportsBackgroundURLSessionUploads`, which checks both for app extensions and app clips and turns off background uploads for both of them.

I have submitted [a separate PR to `firebase-ios-sdk`](https://github.com/firebase/firebase-ios-sdk/pull/14794) to make use of `supportsBackgroundURLSessionUploads`, because as of now [AppClips fail when uploading files](https://github.com/firebase/firebase-ios-sdk/issues/14793).