### PR TITLE
fix(ci): install missing iOS 18.2 simulator runtime

### DIFF
--- a/.github/workflows/google-utilities.yml
+++ b/.github/workflows/google-utilities.yml
@@ -80,6 +80,9 @@ jobs:
       run: |
         sudo xcode-select -s '/Applications/Xcode_16.2.app/Contents/Developer'
         xcodebuild -list
+    - name: Install iOS Simulator
+      if: matrix.target == 'iOS'
+      run: xcodebuild -downloadPlatform iOS
     - name: iOS Unit Tests
       run: scripts/third_party/travis/retry.sh scripts/build.sh GoogleUtilities-Package ${{ matrix.target }} spm
 


### PR DESCRIPTION
The macos-15 runner image lacks the iOS 18.2 simulator runtime for Xcode 16.2, causing CI jobs to fail.

This adds a workflow step to explicitly download the required simulator, ensuring tests can run with the minimum supported Xcode version.