### PR TITLE
Fix NSMapTable crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 8.1.1
-- [fixed] Prevent race condition crashes in GULNetworkURLSession by replacing 
+- [fixed] Prevent race condition crashes in GULNetworkURLSession by replacing
   NSMapTable with thread-safe NSMutableDictionary and locking. (#228)
 
 # 8.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.1
+- [fixed] Prevent race condition crashes in GULNetworkURLSession by replacing 
+  NSMapTable with thread-safe NSMutableDictionary and locking. (#228)
+
 # 8.1.0
 - Add a utility to detect App Clips and make a semantic check for background
   URL sessions. (#220)

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -399,8 +399,8 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   }
 
   // For application:handleEventsForBackgroundURLSession:completionHandler:
-  SEL handleEventsForBackgroundURLSessionSEL = @selector(application:
-                                 handleEventsForBackgroundURLSession:completionHandler:);
+  SEL handleEventsForBackgroundURLSessionSEL =
+      @selector(application:handleEventsForBackgroundURLSession:completionHandler:);
   [self proxyDestinationSelector:handleEventsForBackgroundURLSessionSEL
       implementationsFromSourceSelector:handleEventsForBackgroundURLSessionSEL
                               fromClass:[GULAppDelegateSwizzler class]
@@ -411,8 +411,8 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
 
 #if TARGET_OS_IOS
   // For application:openURL:sourceApplication:annotation:
-  SEL openURLSourceApplicationAnnotationSEL = @selector(application:
-                                                            openURL:sourceApplication:annotation:);
+  SEL openURLSourceApplicationAnnotationSEL =
+      @selector(application:openURL:sourceApplication:annotation:);
 
   [self proxyDestinationSelector:openURLSourceApplicationAnnotationSEL
       implementationsFromSourceSelector:openURLSourceApplicationAnnotationSEL
@@ -477,8 +477,8 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // For application:didRegisterForRemoteNotificationsWithDeviceToken:
   SEL didRegisterForRemoteNotificationsSEL =
       NSSelectorFromString(kGULDidRegisterForRemoteNotificationsSEL);
-  SEL didRegisterForRemoteNotificationsDonorSEL = @selector(application:
-                 donor_didRegisterForRemoteNotificationsWithDeviceToken:);
+  SEL didRegisterForRemoteNotificationsDonorSEL =
+      @selector(application:donor_didRegisterForRemoteNotificationsWithDeviceToken:);
 
   [self proxyDestinationSelector:didRegisterForRemoteNotificationsSEL
       implementationsFromSourceSelector:didRegisterForRemoteNotificationsDonorSEL
@@ -490,8 +490,8 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   // For application:didFailToRegisterForRemoteNotificationsWithError:
   SEL didFailToRegisterForRemoteNotificationsSEL =
       NSSelectorFromString(kGULDidFailToRegisterForRemoteNotificationsSEL);
-  SEL didFailToRegisterForRemoteNotificationsDonorSEL = @selector(application:
-                       donor_didFailToRegisterForRemoteNotificationsWithError:);
+  SEL didFailToRegisterForRemoteNotificationsDonorSEL =
+      @selector(application:donor_didFailToRegisterForRemoteNotificationsWithError:);
 
   [self proxyDestinationSelector:didFailToRegisterForRemoteNotificationsSEL
       implementationsFromSourceSelector:didFailToRegisterForRemoteNotificationsDonorSEL
@@ -747,8 +747,8 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
     handleEventsForBackgroundURLSession:(NSString *)identifier
                       completionHandler:(void (^)())completionHandler {
 #pragma clang diagnostic pop
-  SEL methodSelector = @selector(application:
-         handleEventsForBackgroundURLSession:completionHandler:);
+  SEL methodSelector =
+      @selector(application:handleEventsForBackgroundURLSession:completionHandler:);
   NSValue *handleBackgroundSessionPointer =
       [GULAppDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
   GULRealHandleEventsForBackgroundURLSessionIMP handleBackgroundSessionIMP =

--- a/GoogleUtilities/Network/GULNetwork.m
+++ b/GoogleUtilities/Network/GULNetwork.m
@@ -273,12 +273,12 @@ static NSString *const kGULNetworkLogTag = @"Google/Utilities/Network";
   // Explicitly check whether the delegate responds to the methods because conformsToProtocol does
   // not work correctly even though the delegate does respond to the methods.
   if (!loggerDelegate ||
-      ![loggerDelegate respondsToSelector:@selector(GULNetwork_logWithLevel:
-                                                                messageCode:message:contexts:)] ||
-      ![loggerDelegate respondsToSelector:@selector(GULNetwork_logWithLevel:
-                                                                messageCode:message:context:)] ||
-      ![loggerDelegate respondsToSelector:@selector(GULNetwork_logWithLevel:
-                                                                messageCode:message:)]) {
+      ![loggerDelegate
+          respondsToSelector:@selector(GULNetwork_logWithLevel:messageCode:message:contexts:)] ||
+      ![loggerDelegate
+          respondsToSelector:@selector(GULNetwork_logWithLevel:messageCode:message:context:)] ||
+      ![loggerDelegate
+          respondsToSelector:@selector(GULNetwork_logWithLevel:messageCode:message:)]) {
     GULOSLogError(
         kGULLogSubsystem, kGULLoggerNetwork, NO,
         [NSString stringWithFormat:@"I-NET%06ld", (long)kGULNetworkMessageCodeNetwork002],

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -698,11 +698,13 @@
   if (session) {
     // Cleanup nil entries.
     NSMutableArray *keysToRemove = [[NSMutableArray alloc] init];
-    [[[self class] sessionIDToFetcherMap] enumerateKeysAndObjectsUsingBlock:^(NSString *key, GULNetworkURLSessionWeakHolder *holder, BOOL *stop) {
-      if (holder.session == nil) {
-        [keysToRemove addObject:key];
-      }
-    }];
+    [[[self class] sessionIDToFetcherMap]
+        enumerateKeysAndObjectsUsingBlock:^(NSString *key, GULNetworkURLSessionWeakHolder *holder,
+                                            BOOL *stop) {
+          if (holder.session == nil) {
+            [keysToRemove addObject:key];
+          }
+        }];
     [[[self class] sessionIDToFetcherMap] removeObjectsForKeys:keysToRemove];
 
     GULNetworkURLSessionWeakHolder *newHolder = [[GULNetworkURLSessionWeakHolder alloc] init];

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -696,6 +696,15 @@
     [existingSession->_URLSession finishTasksAndInvalidate];
   }
   if (session) {
+    // Cleanup nil entries.
+    NSMutableArray *keysToRemove = [[NSMutableArray alloc] init];
+    [[[self class] sessionIDToFetcherMap] enumerateKeysAndObjectsUsingBlock:^(NSString *key, GULNetworkURLSessionWeakHolder *holder, BOOL *stop) {
+      if (holder.session == nil) {
+        [keysToRemove addObject:key];
+      }
+    }];
+    [[[self class] sessionIDToFetcherMap] removeObjectsForKeys:keysToRemove];
+
     GULNetworkURLSessionWeakHolder *newHolder = [[GULNetworkURLSessionWeakHolder alloc] init];
     newHolder.session = session;
     [[[self class] sessionIDToFetcherMap] setObject:newHolder forKey:sessionID];

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -28,6 +28,13 @@
                                     NSURLSessionTaskDelegate>
 @end
 
+@interface GULNetworkURLSessionWeakHolder : NSObject
+@property(nonatomic, weak) GULNetworkURLSession *session;
+@end
+
+@implementation GULNetworkURLSessionWeakHolder
+@end
+
 @implementation GULNetworkURLSession {
   /// The handler to be called when the request completes or error has occurs.
   GULNetworkURLSessionCompletionHandler _completionHandler;
@@ -552,12 +559,12 @@
 /// When reading and writing from/to the session map, don't use this method directly.
 /// To avoid thread safety issues, use one of the helper methods at the bottom of the
 /// file: setSessionInFetcherMap:forSessionID:, sessionFromFetcherMapForSessionID:
-+ (NSMapTable<NSString *, GULNetworkURLSession *> *)sessionIDToFetcherMap {
-  static NSMapTable *sessionIDToFetcherMap;
++ (NSMutableDictionary<NSString *, GULNetworkURLSessionWeakHolder *> *)sessionIDToFetcherMap {
+  static NSMutableDictionary *sessionIDToFetcherMap;
 
   static dispatch_once_t sessionMapOnceToken;
   dispatch_once(&sessionMapOnceToken, ^{
-    sessionIDToFetcherMap = [NSMapTable strongToWeakObjectsMapTable];
+    sessionIDToFetcherMap = [[NSMutableDictionary alloc] init];
   });
   return sessionIDToFetcherMap;
 }
@@ -673,8 +680,9 @@
 
 + (void)setSessionInFetcherMap:(GULNetworkURLSession *)session forSessionID:(NSString *)sessionID {
   [[self sessionIDToFetcherMapReadWriteLock] lock];
-  GULNetworkURLSession *existingSession =
+  GULNetworkURLSessionWeakHolder *holder =
       [[[self class] sessionIDToFetcherMap] objectForKey:sessionID];
+  GULNetworkURLSession *existingSession = holder.session;
   if (existingSession) {
     if (session) {
       NSString *message = [NSString stringWithFormat:@"Discarding session: %@", existingSession];
@@ -685,7 +693,9 @@
     [existingSession->_URLSession finishTasksAndInvalidate];
   }
   if (session) {
-    [[[self class] sessionIDToFetcherMap] setObject:session forKey:sessionID];
+    GULNetworkURLSessionWeakHolder *newHolder = [[GULNetworkURLSessionWeakHolder alloc] init];
+    newHolder.session = session;
+    [[[self class] sessionIDToFetcherMap] setObject:newHolder forKey:sessionID];
   } else {
     [[[self class] sessionIDToFetcherMap] removeObjectForKey:sessionID];
   }
@@ -694,7 +704,9 @@
 
 + (nullable GULNetworkURLSession *)sessionFromFetcherMapForSessionID:(NSString *)sessionID {
   [[self sessionIDToFetcherMapReadWriteLock] lock];
-  GULNetworkURLSession *session = [[[self class] sessionIDToFetcherMap] objectForKey:sessionID];
+  GULNetworkURLSessionWeakHolder *holder =
+      [[[self class] sessionIDToFetcherMap] objectForKey:sessionID];
+  GULNetworkURLSession *session = holder.session;
   [[self sessionIDToFetcherMapReadWriteLock] unlock];
   return session;
 }

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -679,6 +679,9 @@
 #pragma mark - Helper Methods
 
 + (void)setSessionInFetcherMap:(GULNetworkURLSession *)session forSessionID:(NSString *)sessionID {
+  if (!sessionID) {
+    return;
+  }
   [[self sessionIDToFetcherMapReadWriteLock] lock];
   GULNetworkURLSessionWeakHolder *holder =
       [[[self class] sessionIDToFetcherMap] objectForKey:sessionID];
@@ -703,6 +706,9 @@
 }
 
 + (nullable GULNetworkURLSession *)sessionFromFetcherMapForSessionID:(NSString *)sessionID {
+  if (!sessionID) {
+    return nil;
+  }
   [[self sessionIDToFetcherMapReadWriteLock] lock];
   GULNetworkURLSessionWeakHolder *holder =
       [[[self class] sessionIDToFetcherMap] objectForKey:sessionID];

--- a/GoogleUtilities/Tests/Unit/Network/GULMutableDictionaryTest.m
+++ b/GoogleUtilities/Tests/Unit/Network/GULMutableDictionaryTest.m
@@ -15,6 +15,12 @@
 #import <XCTest/XCTest.h>
 
 #import "GoogleUtilities/Network/Public/GoogleUtilities/GULMutableDictionary.h"
+#import "GoogleUtilities/Network/Public/GoogleUtilities/GULNetworkURLSession.h"
+
+@interface GULNetworkURLSession (Test)
++ (void)setSessionInFetcherMap:(GULNetworkURLSession *)session forSessionID:(NSString *)sessionID;
++ (nullable GULNetworkURLSession *)sessionFromFetcherMapForSessionID:(NSString *)sessionID;
+@end
 
 const static NSString *const kKey = @"testKey1";
 const static NSString *const kValue = @"testValue1";
@@ -82,6 +88,48 @@ const static NSString *const kValue2 = @"testValue2";
   XCTAssertEqual([dict count], 2);
   XCTAssertEqual(dict[kKey], kValue);
   XCTAssertEqual(dict[kKey2], kValue2);
+}
+
+- (void)testSessionMapStress {
+  int iterations = 1000;
+  int numSessionIDs = 10;
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Stress test finished"];
+
+  dispatch_queue_t queue =
+      dispatch_queue_create("com.google.utilities.stress", DISPATCH_QUEUE_CONCURRENT);
+
+  dispatch_group_t group = dispatch_group_create();
+
+  // Reader threads
+  for (int t = 0; t < 5; t++) {
+    dispatch_group_async(group, queue, ^{
+      for (int i = 0; i < iterations; i++) {
+        int id_idx = i % numSessionIDs;
+        NSString *sessionID = [NSString stringWithFormat:@"session_%d", id_idx];
+        [GULNetworkURLSession sessionFromFetcherMapForSessionID:sessionID];
+      }
+    });
+  }
+
+  // Writer threads
+  for (int t = 0; t < 5; t++) {
+    dispatch_group_async(group, queue, ^{
+      for (int i = 0; i < iterations; i++) {
+        int id_idx = i % numSessionIDs;
+        NSString *sessionID = [NSString stringWithFormat:@"session_%d", id_idx];
+        GULNetworkURLSession *session =
+            [[GULNetworkURLSession alloc] initWithNetworkLoggerDelegate:nil];
+        [GULNetworkURLSession setSessionInFetcherMap:session forSessionID:sessionID];
+      }
+    });
+  }
+
+  dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
 @end

--- a/GoogleUtilities/Tests/Unit/Network/GULNetworkTest.m
+++ b/GoogleUtilities/Tests/Unit/Network/GULNetworkTest.m
@@ -37,6 +37,11 @@
 
 @end
 
+@interface GULNetworkURLSession (Test)
++ (void)setSessionInFetcherMap:(GULNetworkURLSession *)session forSessionID:(NSString *)sessionID;
++ (nullable GULNetworkURLSession *)sessionFromFetcherMapForSessionID:(NSString *)sessionID;
+@end
+
 @interface GULNetworkTest : XCTestCase <GULNetworkReachabilityDelegate>
 @end
 
@@ -1089,6 +1094,48 @@
 
 - (void)reachabilityDidChange {
   _currentNetworkStatus = _fakeNetworkIsReachable;
+}
+
+- (void)testSessionMapStress {
+  int iterations = 1000;
+  int numSessionIDs = 10;
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Stress test finished"];
+
+  dispatch_queue_t queue =
+      dispatch_queue_create("com.google.utilities.stress", DISPATCH_QUEUE_CONCURRENT);
+
+  dispatch_group_t group = dispatch_group_create();
+
+  // Reader threads
+  for (int t = 0; t < 5; t++) {
+    dispatch_group_async(group, queue, ^{
+      for (int i = 0; i < iterations; i++) {
+        int id_idx = i % numSessionIDs;
+        NSString *sessionID = [NSString stringWithFormat:@"session_%d", id_idx];
+        [GULNetworkURLSession sessionFromFetcherMapForSessionID:sessionID];
+      }
+    });
+  }
+
+  // Writer threads
+  for (int t = 0; t < 5; t++) {
+    dispatch_group_async(group, queue, ^{
+      for (int i = 0; i < iterations; i++) {
+        int id_idx = i % numSessionIDs;
+        NSString *sessionID = [NSString stringWithFormat:@"session_%d", id_idx];
+        GULNetworkURLSession *session =
+            [[GULNetworkURLSession alloc] initWithNetworkLoggerDelegate:nil];
+        [GULNetworkURLSession setSessionInFetcherMap:session forSessionID:sessionID];
+      }
+    });
+  }
+
+  dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
 @end

--- a/GoogleUtilities/Tests/Unit/Swizzler/GULAppDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Tests/Unit/Swizzler/GULAppDelegateSwizzlerTest.m
@@ -107,8 +107,8 @@ static BOOL gRespondsToHandleBackgroundSession;
   gRespondsToOpenURLHandler_iOS9 =
       [self instancesRespondToSelector:@selector(application:openURL:options:)];
   gRespondsToHandleBackgroundSession =
-      [self instancesRespondToSelector:@selector(application:
-                                           handleEventsForBackgroundURLSession:completionHandler:)];
+      [self instancesRespondToSelector:
+                @selector(application:handleEventsForBackgroundURLSession:completionHandler:)];
   gRespondsToContinueUserActivity = [self
       instancesRespondToSelector:@selector(application:continueUserActivity:restorationHandler:)];
 #pragma clang diagnostic pop
@@ -292,22 +292,22 @@ static BOOL gRespondsToHandleBackgroundSession;
   // Class size must stay the same.
   XCTAssertEqual(sizeBefore, sizeAfter);
 
-  XCTAssertTrue([realAppDelegate respondsToSelector:@selector(application:
-                                                        continueUserActivity:restorationHandler:)]);
+  XCTAssertTrue([realAppDelegate
+      respondsToSelector:@selector(application:continueUserActivity:restorationHandler:)]);
   XCTAssertTrue([realAppDelegate
       respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
   XCTAssertTrue([realAppDelegate
       respondsToSelector:@selector(application:didFailToRegisterForRemoteNotificationsWithError:)]);
-  XCTAssertTrue([realAppDelegate respondsToSelector:@selector(application:
-                                                        didReceiveRemoteNotification:)]);
+  XCTAssertTrue(
+      [realAppDelegate respondsToSelector:@selector(application:didReceiveRemoteNotification:)]);
 #if TARGET_OS_IOS || TARGET_OS_TV
   XCTAssertTrue([realAppDelegate respondsToSelector:@selector(application:openURL:options:)]);
   XCTAssertTrue([realAppDelegate
-      respondsToSelector:@selector(application:
-                             handleEventsForBackgroundURLSession:completionHandler:)]);
+      respondsToSelector:@selector(
+                             application:handleEventsForBackgroundURLSession:completionHandler:)]);
   XCTAssertTrue([realAppDelegate
-      respondsToSelector:@selector(application:
-                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
+      respondsToSelector:@selector(
+                             application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 
   // Make sure that the class has changed.
@@ -343,25 +343,25 @@ static BOOL gRespondsToHandleBackgroundSession;
   // Class size must stay the same.
   XCTAssertEqual(sizeBefore, sizeAfter);
 
-  XCTAssertTrue([realAppDelegate respondsToSelector:@selector(application:
-                                                        continueUserActivity:restorationHandler:)]);
+  XCTAssertTrue([realAppDelegate
+      respondsToSelector:@selector(application:continueUserActivity:restorationHandler:)]);
   // Remote notifications methods should be added only by
   // -proxyOriginalDelegateIncludingAPNSMethods
   XCTAssertFalse([realAppDelegate
       respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
   XCTAssertFalse([realAppDelegate
       respondsToSelector:@selector(application:didFailToRegisterForRemoteNotificationsWithError:)]);
-  XCTAssertFalse([realAppDelegate respondsToSelector:@selector(application:
-                                                         didReceiveRemoteNotification:)]);
+  XCTAssertFalse(
+      [realAppDelegate respondsToSelector:@selector(application:didReceiveRemoteNotification:)]);
 #if TARGET_OS_IOS || TARGET_OS_TV
   // The implementation should not be added if there is no original implementation
   XCTAssertFalse([realAppDelegate respondsToSelector:@selector(application:openURL:options:)]);
   XCTAssertTrue([realAppDelegate
-      respondsToSelector:@selector(application:
-                             handleEventsForBackgroundURLSession:completionHandler:)]);
+      respondsToSelector:@selector(
+                             application:handleEventsForBackgroundURLSession:completionHandler:)]);
   XCTAssertFalse([realAppDelegate
-      respondsToSelector:@selector(application:
-                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
+      respondsToSelector:@selector(
+                             application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 
   // Make sure that the class has changed.
@@ -390,8 +390,8 @@ static BOOL gRespondsToHandleBackgroundSession;
   // Class size must stay the same.
   XCTAssertEqual(sizeBefore, sizeAfter);
 
-  XCTAssertTrue([realAppDelegate respondsToSelector:@selector(application:
-                                                        continueUserActivity:restorationHandler:)]);
+  XCTAssertTrue([realAppDelegate
+      respondsToSelector:@selector(application:continueUserActivity:restorationHandler:)]);
 
   // Remote notifications methods should be added only by
   // -proxyOriginalDelegateIncludingAPNSMethods
@@ -405,12 +405,12 @@ static BOOL gRespondsToHandleBackgroundSession;
   XCTAssertFalse([realAppDelegate respondsToSelector:@selector(application:openURL:options:)]);
 
   XCTAssertTrue([realAppDelegate
-      respondsToSelector:@selector(application:
-                             handleEventsForBackgroundURLSession:completionHandler:)]);
+      respondsToSelector:@selector(
+                             application:handleEventsForBackgroundURLSession:completionHandler:)]);
 
   XCTAssertTrue([realAppDelegate
-      respondsToSelector:@selector(application:
-                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
+      respondsToSelector:@selector(
+                             application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
 
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 
@@ -440,8 +440,8 @@ static BOOL gRespondsToHandleBackgroundSession;
   // Class size must stay the same.
   XCTAssertEqual(sizeBefore, sizeAfter);
 
-  XCTAssertTrue([realAppDelegate respondsToSelector:@selector(application:
-                                                        continueUserActivity:restorationHandler:)]);
+  XCTAssertTrue([realAppDelegate
+      respondsToSelector:@selector(application:continueUserActivity:restorationHandler:)]);
   // Proxy remote notifications methods
   [GULAppDelegateSwizzler proxyOriginalDelegateIncludingAPNSMethods];
 
@@ -454,12 +454,12 @@ static BOOL gRespondsToHandleBackgroundSession;
   // The implementation should not be added if there is no original implementation
   XCTAssertFalse([realAppDelegate respondsToSelector:@selector(application:openURL:options:)]);
   XCTAssertTrue([realAppDelegate
-      respondsToSelector:@selector(application:
-                             handleEventsForBackgroundURLSession:completionHandler:)]);
+      respondsToSelector:@selector(
+                             application:handleEventsForBackgroundURLSession:completionHandler:)]);
 
   XCTAssertTrue([realAppDelegate
-      respondsToSelector:@selector(application:
-                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
+      respondsToSelector:@selector(
+                             application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 
   // Make sure that the class has changed.
@@ -1004,13 +1004,15 @@ static BOOL gRespondsToHandleBackgroundSession;
   GULTestInterceptorAppDelegate *delegate = [[GULTestInterceptorAppDelegate alloc] init];
   OCMStub([self.mockSharedApplication delegate]).andReturn(delegate);
 
-  XCTAssertFalse([delegate respondsToSelector:@selector
-                           (application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
+  XCTAssertFalse([delegate
+      respondsToSelector:@selector(
+                             application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
 
   [GULAppDelegateSwizzler proxyOriginalDelegateIncludingAPNSMethods];
 
-  XCTAssertTrue([delegate respondsToSelector:@selector
-                          (application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
+  XCTAssertTrue([delegate
+      respondsToSelector:@selector(
+                             application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
 }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 

--- a/Mintfile
+++ b/Mintfile
@@ -1,1 +1,1 @@
-nicklockwood/SwiftFormat@0.49.2
+nicklockwood/SwiftFormat@0.55.5


### PR DESCRIPTION
Fix #228

This Pull Request ([\#230](https://github.com/google/GoogleUtilities/pull/230/changes)) addresses a crash related to `NSMapTable` in the `GoogleUtilities` library by replacing it with a more stable `NSMutableDictionary` and a custom weak wrapper.

### **Summary of Changes**

The core issue stems from thread-safety or stability problems often associated with `NSMapTable` when using `strongToWeakObjectsMapTable`. The PR introduces a manual "weak holder" pattern to achieve the same goal safely.

---

### **Technical Breakdown**

#### **1\. Introduction of `GULNetworkURLSessionWeakHolder`**

A new internal class is created to hold a `weak` reference to a `GULNetworkURLSession`.

* **Why:** `NSMutableDictionary` does not natively support weak values. By wrapping the session in this object, the dictionary can hold a `strong` reference to the *holder*, while the *holder* maintains a `weak` reference to the actual session.

#### **2\. Data Structure Swap**

In `GULNetworkURLSession.m`, the session mapping logic is updated:

* **Old:** `NSMapTable<NSString *, GULNetworkURLSession *> *sessionIDToFetcherMap`  
* **New:** `NSMutableDictionary<NSString *, GULNetworkURLSessionWeakHolder *> *sessionIDToFetcherMap`

#### **3\. Updated Accessors**

The helper methods `setSessionInFetcherMap:forSessionID:` and `sessionFromFetcherMapForSessionID:` were updated to wrap/unwrap the session object using the new `WeakHolder`.

#### **4\. Stress Testing**

The PR includes significant additions to the unit tests (`GULMutableDictionaryTest.m` and `GULNetworkTest.m`):

* A `testSessionMapStress` method was added to both files.  
* It spawns 5 reader threads and 5 writer threads running 1,000 iterations each to ensure that the new `NSMutableDictionary` implementation (combined with the existing `sessionIDToFetcherMapReadWriteLock`) remains stable under high concurrency.

---

### **Observations**

* **Safety:** The transition to `NSMutableDictionary` is generally safer in Objective-C environments where `NSMapTable`'s background reclamation of weak entries can sometimes lead to race conditions or crashes during high-frequency access.  
* **Memory Management:** Since the dictionary holds a strong reference to the `GULNetworkURLSessionWeakHolder`, the *holder* objects will stay in the dictionary even after the `session` they point to becomes `nil`.  
  * *Note:* The code does include a `removeObjectForKey:` call in the setter if the session is nil, but it doesn't appear to have a periodic "cleanup" for entries where the weak reference died naturally. Given the small number of expected sessions (`numSessionIDs = 10` in tests), this is likely a negligible memory leak.  
* **Test Coverage:** The inclusion of a concurrent stress test is a great addition, as it directly validates the fix against the likely cause of the original crash.
