### PR TITLE
feat: add additional scene delegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Unrelease
+- [feature] Added proxy support for `scene:willConnectToSession:options:` and
+  `scene:continueUserActivity:` to `GULSceneDelegateSwizzler`. Existing implementations
+  will override this behavior, so current scene delegate implementations will
+  continue to work as expected. (#242)
+- [fixed] Fixed a potentional race-condition where `GULSceneDelegateSwizzler`
+  could miss being configured on scene delegates if they were spawned before
+  the proxy was ready. (#242)
+
 # 8.1.2
 - [fixed] Resolve EXC_BAD_ACCESS in GULNetworkURLSession via O(1) passive memory
   lifecycle cleanup. (#233)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unrelease
+# Unreleased
 - [feature] Added proxy support for `scene:willConnectToSession:options:` and
   `scene:continueUserActivity:` to `GULSceneDelegateSwizzler`. Existing implementations
   will override this behavior, so current scene delegate implementations will

--- a/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
@@ -334,12 +334,7 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
     [GULSceneDelegateSwizzler
         notifyInterceptorsWithMethodSelector:methodSelector
                                     callback:^(id<UISceneDelegate> interceptor) {
-                                      if ([interceptor
-                                              conformsToProtocol:@protocol(UISceneDelegate)]) {
-                                        id<UISceneDelegate> sceneInterceptor =
-                                            (id<UISceneDelegate>)interceptor;
-                                        [sceneInterceptor scene:scene openURLContexts:URLContexts];
-                                      }
+                                      [interceptor scene:scene openURLContexts:URLContexts];
                                     }];
 
     if (openURLContextsIMP) {

--- a/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
@@ -359,47 +359,43 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
     willConnectToSession:(UISceneSession *)session
                  options:(UISceneConnectionOptions *)connectionOptions
     API_AVAILABLE(ios(13.0), tvos(13.0)) {
-  if (@available(iOS 13.0, tvOS 13.0, *)) {
-    SEL methodSelector = @selector(scene:willConnectToSession:options:);
-    NSValue *willConnectToSessionIMPPointer =
-        [GULSceneDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
-    GULWillConnectToSessionIMP willConnectToSessionIMP =
-        [willConnectToSessionIMPPointer pointerValue];
+  SEL methodSelector = @selector(scene:willConnectToSession:options:);
+  NSValue *willConnectToSessionIMPPointer =
+      [GULSceneDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
+  GULWillConnectToSessionIMP willConnectToSessionIMP =
+      [willConnectToSessionIMPPointer pointerValue];
 
-    [GULSceneDelegateSwizzler
-        notifyInterceptorsWithMethodSelector:methodSelector
-                                    callback:^(id<UISceneDelegate> interceptor) {
-                                      [interceptor scene:scene
-                                          willConnectToSession:session
-                                                       options:connectionOptions];
-                                    }];
+  [GULSceneDelegateSwizzler
+      notifyInterceptorsWithMethodSelector:methodSelector
+                                  callback:^(id<UISceneDelegate> interceptor) {
+                                    [interceptor scene:scene
+                                        willConnectToSession:session
+                                                     options:connectionOptions];
+                                  }];
 
-    // Call the real implementation if the real Scene Delegate has any.
-    if (willConnectToSessionIMP) {
-      willConnectToSessionIMP(self, methodSelector, scene, session, connectionOptions);
-    }
+  // Call the real implementation if the real Scene Delegate has any.
+  if (willConnectToSessionIMP) {
+    willConnectToSessionIMP(self, methodSelector, scene, session, connectionOptions);
   }
 }
 
 - (void)scene:(UIScene *)scene
     continueUserActivity:(NSUserActivity *)userActivity API_AVAILABLE(ios(13.0), tvos(13.0)) {
-  if (@available(iOS 13.0, tvOS 13.0, *)) {
-    SEL methodSelector = @selector(scene:continueUserActivity:);
-    NSValue *continueUserActivityIMPPointer =
-        [GULSceneDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
-    GULContinueUserActivityIMP continueUserActivityIMP =
-        [continueUserActivityIMPPointer pointerValue];
+  SEL methodSelector = @selector(scene:continueUserActivity:);
+  NSValue *continueUserActivityIMPPointer =
+      [GULSceneDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
+  GULContinueUserActivityIMP continueUserActivityIMP =
+      [continueUserActivityIMPPointer pointerValue];
 
-    [GULSceneDelegateSwizzler
-        notifyInterceptorsWithMethodSelector:methodSelector
-                                    callback:^(id<UISceneDelegate> interceptor) {
-                                      [interceptor scene:scene continueUserActivity:userActivity];
-                                    }];
+  [GULSceneDelegateSwizzler
+      notifyInterceptorsWithMethodSelector:methodSelector
+                                  callback:^(id<UISceneDelegate> interceptor) {
+                                    [interceptor scene:scene continueUserActivity:userActivity];
+                                  }];
 
-    // Call the real implementation if the real Scene Delegate has any.
-    if (continueUserActivityIMP) {
-      continueUserActivityIMP(self, methodSelector, scene, userActivity);
-    }
+  // Call the real implementation if the real Scene Delegate has any.
+  if (continueUserActivityIMP) {
+    continueUserActivityIMP(self, methodSelector, scene, userActivity);
   }
 }
 

--- a/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
@@ -30,6 +30,13 @@ API_AVAILABLE(ios(13.0), tvos(13.0))
 typedef void (*GULOpenURLContextsIMP)(id, SEL, UIScene *, NSSet<UIOpenURLContext *> *);
 
 API_AVAILABLE(ios(13.0), tvos(13.0))
+typedef void (*GULWillConnectToSessionIMP)(
+    id, SEL, UIScene *, UISceneSession *, UISceneConnectionOptions *);
+
+API_AVAILABLE(ios(13.0), tvos(13.0))
+typedef void (*GULContinueUserActivityIMP)(id, SEL, UIScene *, NSUserActivity *);
+
+API_AVAILABLE(ios(13.0), tvos(13.0))
 typedef void (^GULSceneDelegateInterceptorCallback)(id<UISceneDelegate>);
 
 // The strings below are the keys for associated objects.
@@ -341,6 +348,54 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   }
 }
 
+- (void)scene:(UIScene *)scene
+    willConnectToSession:(UISceneSession *)session
+                 options:(UISceneConnectionOptions *)connectionOptions
+    API_AVAILABLE(ios(13.0), tvos(13.0)) {
+  if (@available(iOS 13.0, tvOS 13.0, *)) {
+    SEL methodSelector = @selector(scene:willConnectToSession:options:);
+    NSValue *willConnectToSessionIMPPointer =
+        [GULSceneDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
+    GULWillConnectToSessionIMP willConnectToSessionIMP =
+        [willConnectToSessionIMPPointer pointerValue];
+
+    [GULSceneDelegateSwizzler
+        notifyInterceptorsWithMethodSelector:methodSelector
+                                    callback:^(id<UISceneDelegate> interceptor) {
+                                      [interceptor scene:scene
+                                          willConnectToSession:session
+                                                       options:connectionOptions];
+                                    }];
+
+    // Call the real implementation if the real Scene Delegate has any.
+    if (willConnectToSessionIMP) {
+      willConnectToSessionIMP(self, methodSelector, scene, session, connectionOptions);
+    }
+  }
+}
+
+- (void)scene:(UIScene *)scene
+    continueUserActivity:(NSUserActivity *)userActivity API_AVAILABLE(ios(13.0), tvos(13.0)) {
+  if (@available(iOS 13.0, tvOS 13.0, *)) {
+    SEL methodSelector = @selector(scene:continueUserActivity:);
+    NSValue *continueUserActivityIMPPointer =
+        [GULSceneDelegateSwizzler originalImplementationForSelector:methodSelector object:self];
+    GULContinueUserActivityIMP continueUserActivityIMP =
+        [continueUserActivityIMPPointer pointerValue];
+
+    [GULSceneDelegateSwizzler
+        notifyInterceptorsWithMethodSelector:methodSelector
+                                    callback:^(id<UISceneDelegate> interceptor) {
+                                      [interceptor scene:scene continueUserActivity:userActivity];
+                                    }];
+
+    // Call the real implementation if the real Scene Delegate has any.
+    if (continueUserActivityIMP) {
+      continueUserActivityIMP(self, methodSelector, scene, userActivity);
+    }
+  }
+}
+
 + (void)proxySceneDelegateIfNeeded:(UIScene *)scene {
   Class realClass = [scene.delegate class];
   NSString *className = NSStringFromClass(realClass);
@@ -391,6 +446,24 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
   SEL openURLContextsSEL = @selector(scene:openURLContexts:);
   [self proxyDestinationSelector:openURLContextsSEL
       implementationsFromSourceSelector:openURLContextsSEL
+                              fromClass:[GULSceneDelegateSwizzler class]
+                                toClass:sceneDelegateSubClass
+                              realClass:realClass
+       storeDestinationImplementationTo:realImplementationsBySelector];
+
+  // For scene:willConnectToSession:options:
+  SEL willConnectToSessionSEL = @selector(scene:willConnectToSession:options:);
+  [self proxyDestinationSelector:willConnectToSessionSEL
+      implementationsFromSourceSelector:willConnectToSessionSEL
+                              fromClass:[GULSceneDelegateSwizzler class]
+                                toClass:sceneDelegateSubClass
+                              realClass:realClass
+       storeDestinationImplementationTo:realImplementationsBySelector];
+
+  // For scene:continueUserActivity:
+  SEL continueUserActivitySEL = @selector(scene:continueUserActivity:);
+  [self proxyDestinationSelector:continueUserActivitySEL
+      implementationsFromSourceSelector:continueUserActivitySEL
                               fromClass:[GULSceneDelegateSwizzler class]
                                 toClass:sceneDelegateSubClass
                               realClass:realClass

--- a/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULSceneDelegateSwizzler.m
@@ -103,6 +103,18 @@ static NSString *const kGULSceneDelegatePrefix = @"GUL_";
              selector:@selector(handleSceneWillConnectToNotification:)
                  name:UISceneWillConnectNotification
                object:nil];
+
+      // For catching scene delegates that were already connected when swizzling started,
+      // which may or may not be an actual problem. Not sure, but better safe than sorry.
+      id sharedApplication = [GULAppDelegateSwizzler sharedApplication];
+      if ([sharedApplication respondsToSelector:@selector(openSessions)]) {
+        NSSet<UISceneSession *> *sessions = [sharedApplication openSessions];
+        for (UISceneSession *session in sessions) {
+          if (session.scene) {
+            [GULSceneDelegateSwizzler proxySceneDelegateIfNeeded:session.scene];
+          }
+        }
+      }
     }
   });
 #endif  // UISCENE_SUPPORTED

--- a/GoogleUtilities/Tests/Unit/Swizzler/GULSceneDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Tests/Unit/Swizzler/GULSceneDelegateSwizzlerTest.m
@@ -45,10 +45,38 @@ API_AVAILABLE(ios(13.0), tvos(13.0))
 @implementation GULTestSceneDelegate
 @end
 
+API_AVAILABLE(ios(13.0), tvos(13.0))
+@interface GULImplementingTestSceneDelegate : NSObject <UISceneDelegate>
+@property(nonatomic, assign) BOOL openURLContextsInvoked;
+@property(nonatomic, assign) BOOL willConnectToSessionOptionsInvoked;
+@property(nonatomic, assign) BOOL continueUserActivityInvoked;
+@end
+
+@implementation GULImplementingTestSceneDelegate
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
+  _openURLContextsInvoked = YES;
+}
+- (void)scene:(UIScene *)scene
+    willConnectToSession:(UISceneSession *)session
+                 options:(UISceneConnectionOptions *)connectionOptions {
+  _willConnectToSessionOptionsInvoked = YES;
+}
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
+  _continueUserActivityInvoked = YES;
+}
+@end
+
 @interface GULSceneDelegateSwizzlerTest : XCTestCase
 @end
 
 @implementation GULSceneDelegateSwizzlerTest
+
+- (void)tearDown {
+  if (@available(iOS 13.0, tvOS 13.0, *)) {
+    [GULSceneDelegateSwizzler clearInterceptors];
+  }
+  [super tearDown];
+}
 
 - (void)testProxySceneDelegateWithNoSceneDelegate {
   if (@available(iOS 13, tvOS 13, *)) {
@@ -85,6 +113,9 @@ API_AVAILABLE(ios(13.0), tvos(13.0))
 
     // After being proxied, it should be able to respond to the required method selector.
     XCTAssertTrue([realSceneDelegate respondsToSelector:@selector(scene:openURLContexts:)]);
+    XCTAssertTrue(
+        [realSceneDelegate respondsToSelector:@selector(scene:willConnectToSession:options:)]);
+    XCTAssertTrue([realSceneDelegate respondsToSelector:@selector(scene:continueUserActivity:)]);
 
     // Make sure that the class has changed.
     XCTAssertNotEqualObjects([realSceneDelegate class], realSceneDelegateClassBefore);
@@ -141,6 +172,118 @@ API_AVAILABLE(ios(13.0), tvos(13.0))
 
     [mockSharedScene stopMocking];
     mockSharedScene = nil;
+  }
+}
+
+- (void)testSceneWillConnectToSessionOptionsIsInvokedOnInterceptors {
+  if (@available(iOS 13, tvOS 13, *)) {
+    id mockSession = OCMClassMock([UISceneSession class]);
+    id mockConnectionOptions = OCMClassMock([UISceneConnectionOptions class]);
+
+    GULTestSceneDelegate *realSceneDelegate = [[GULTestSceneDelegate alloc] init];
+    id mockSharedScene = OCMClassMock([UIScene class]);
+    OCMStub([mockSharedScene delegate]).andReturn(realSceneDelegate);
+
+    id interceptor = OCMProtocolMock(@protocol(TestSceneProtocol));
+    OCMExpect([interceptor scene:mockSharedScene
+            willConnectToSession:mockSession
+                         options:mockConnectionOptions]);
+
+    id interceptor2 = OCMProtocolMock(@protocol(TestSceneProtocol));
+    OCMExpect([interceptor2 scene:mockSharedScene
+             willConnectToSession:mockSession
+                          options:mockConnectionOptions]);
+
+    [GULSceneDelegateSwizzler proxySceneDelegateIfNeeded:mockSharedScene];
+
+    [GULSceneDelegateSwizzler registerSceneDelegateInterceptor:interceptor];
+    [GULSceneDelegateSwizzler registerSceneDelegateInterceptor:interceptor2];
+
+    [realSceneDelegate scene:mockSharedScene
+        willConnectToSession:mockSession
+                     options:mockConnectionOptions];
+    OCMVerifyAll(interceptor);
+    OCMVerifyAll(interceptor2);
+
+    [mockSharedScene stopMocking];
+    [mockSession stopMocking];
+    [mockConnectionOptions stopMocking];
+    mockSharedScene = nil;
+    mockSession = nil;
+    mockConnectionOptions = nil;
+  }
+}
+
+- (void)testSceneContinueUserActivityIsInvokedOnInterceptors {
+  if (@available(iOS 13, tvOS 13, *)) {
+    NSUserActivity *userActivity =
+        [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+
+    GULTestSceneDelegate *realSceneDelegate = [[GULTestSceneDelegate alloc] init];
+    id mockSharedScene = OCMClassMock([UIScene class]);
+    OCMStub([mockSharedScene delegate]).andReturn(realSceneDelegate);
+
+    id interceptor = OCMProtocolMock(@protocol(TestSceneProtocol));
+    OCMExpect([interceptor scene:mockSharedScene continueUserActivity:userActivity]);
+
+    id interceptor2 = OCMProtocolMock(@protocol(TestSceneProtocol));
+    OCMExpect([interceptor2 scene:mockSharedScene continueUserActivity:userActivity]);
+
+    [GULSceneDelegateSwizzler proxySceneDelegateIfNeeded:mockSharedScene];
+
+    [GULSceneDelegateSwizzler registerSceneDelegateInterceptor:interceptor];
+    [GULSceneDelegateSwizzler registerSceneDelegateInterceptor:interceptor2];
+
+    [realSceneDelegate scene:mockSharedScene continueUserActivity:userActivity];
+    OCMVerifyAll(interceptor);
+    OCMVerifyAll(interceptor2);
+
+    [mockSharedScene stopMocking];
+    mockSharedScene = nil;
+  }
+}
+
+- (void)testDonorMethodsInvokeOriginalSceneDelegateImplementations {
+  if (@available(iOS 13, tvOS 13, *)) {
+    GULImplementingTestSceneDelegate *realSceneDelegate =
+        [[GULImplementingTestSceneDelegate alloc] init];
+    id mockSharedScene = OCMClassMock([UIScene class]);
+    OCMStub([mockSharedScene delegate]).andReturn(realSceneDelegate);
+
+    id interceptor = OCMProtocolMock(@protocol(TestSceneProtocol));
+    OCMExpect([interceptor scene:mockSharedScene openURLContexts:[NSSet set]]);
+
+    [GULSceneDelegateSwizzler proxySceneDelegateIfNeeded:mockSharedScene];
+    [GULSceneDelegateSwizzler registerSceneDelegateInterceptor:interceptor];
+
+    [realSceneDelegate scene:mockSharedScene openURLContexts:[NSSet set]];
+    OCMVerifyAll(interceptor);
+    XCTAssertTrue(realSceneDelegate.openURLContextsInvoked);
+
+    id mockSession = OCMClassMock([UISceneSession class]);
+    id mockConnectionOptions = OCMClassMock([UISceneConnectionOptions class]);
+    OCMExpect([interceptor scene:mockSharedScene
+            willConnectToSession:mockSession
+                         options:mockConnectionOptions]);
+    [realSceneDelegate scene:mockSharedScene
+        willConnectToSession:mockSession
+                     options:mockConnectionOptions];
+    OCMVerifyAll(interceptor);
+    XCTAssertTrue(realSceneDelegate.willConnectToSessionOptionsInvoked);
+
+    NSUserActivity *userActivity =
+        [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+    OCMExpect([interceptor scene:mockSharedScene continueUserActivity:userActivity]);
+    [realSceneDelegate scene:mockSharedScene continueUserActivity:userActivity];
+    OCMVerifyAll(interceptor);
+    XCTAssertTrue(realSceneDelegate.continueUserActivityInvoked);
+
+    [mockSharedScene stopMocking];
+    [mockSession stopMocking];
+    [mockConnectionOptions stopMocking];
+    mockSharedScene = nil;
+    mockSession = nil;
+    mockConnectionOptions = nil;
   }
 }
 


### PR DESCRIPTION
Per [b/532968854](https://buganizer.corp.google.com/issues/532968854),

This adds functionality to `GULSceneDelegateSwizzler` to properly proxy both `scene:willConnectToSession:options:` and `scene:continueUserActivity:`, as the alternatives were already being proxied within the app delegate swizzler.

Tests have also been added for these. Note that these methods check if the developer already had an implementation, and call it directly instead of handling it in those cases. This should ensure that existing implementations aren't broken by this change.

This PR also removes a small bit of redundant code in the `scene:openURLContexts:` proxy method. The code was previously explicitly checking protocol conformance and casts inside the interceptor block, but this was already being performed by the parent `notifyInterceptorsWithMethodSelector` method, so it's a bit redundant.

Furthermore, this PR adds a bit of code that will also attempt to proxy existing scene delegates that were already connected when our code started. It may not be an issue, but with the lifecycle nuances of newer Swift ecosystems (especially around Scenes), I thought it better safe than sorry; as it could also address any potential edge-cases.